### PR TITLE
Addition of "Identity Hub" module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Though these specifications are not on the W3C standards track, adherance to the
 The [W3C Credentials Community Group](https://w3c-ccg.github.io/) [Universal Wallet Interop Specification](https://w3c-ccg.github.io/universal-wallet-interop-spec/) provides a model for how wallet data could be made interoperable between other wallet implementations.
 
 #### VC API
-The [W3C Credentials Community Group](https://w3c-ccg.github.io/) [VC API Specification](https://w3c-ccg.github.io/universal-wallet-interop-spec/) provides a data model and HTTP protocols to issue, verify, present, and manage verifiable credentials on the Web.
+The [W3C Credentials Community Group](https://w3c-ccg.github.io/) [VC API Specification](https://w3c-ccg.github.io/vc-api/) provides a data model and HTTP protocols to issue, verify, present, and manage verifiable credentials on the Web.
 The [W3C Credentials Community Group](https://w3c-ccg.github.io/) also publishes [use cases for VC API](https://w3c-ccg.github.io/vc-api-use-cases/index.html).
 
 ### DIF Wallet Security Group
@@ -76,8 +76,8 @@ const did = generateDID(key); // Code from ssi-did lib. Returns initial DID Docu
 ### Key Module
 The key module is kept separate from the DID module because it's plausible that key module will be provided by a different service (i.e. a dedicated KMS) at some point.
 
-### Issuer Module
-Implements the [vc-issuer specification](https://w3c-ccg.github.io/vc-api/issuer.html) from the [W3C Credentials Community Group](https://w3c-ccg.github.io/).
+### VC API Module
+Implements the [vc-issuer specification](https://w3c-ccg.github.io/vc-api/) from the [W3C Credentials Community Group](https://w3c-ccg.github.io/).
 
 ## NestJS Wallet Implementation Notes
 - Uses **in-memory DB** for now for app execution and tests.

--- a/apps/nestjs-wallet/package.json
+++ b/apps/nestjs-wallet/package.json
@@ -42,7 +42,8 @@
     "class-transformer": "~0.4.0",
     "@nestjs/swagger": "~5.1.5",
     "swagger-ui-express": "~4.1.6",
-    "uuid": "~8.3.2"
+    "uuid": "~8.3.2",
+    "multiformats": "~9.6.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",

--- a/apps/nestjs-wallet/src/app.module.ts
+++ b/apps/nestjs-wallet/src/app.module.ts
@@ -7,6 +7,7 @@ import { VcApiModule } from './vc-api/vc-api.module';
 import { DIDContactModule } from './did-contact/did-contact.module';
 import { TypeOrmSQLiteModule } from './in-memory-db';
 import { EliaIssuerModule } from './elia-issuer/elia-issuer.module';
+import { IdentityHubModule } from './identity-hub/identity-hub.module';
 
 @Module({
   imports: [
@@ -17,7 +18,8 @@ import { EliaIssuerModule } from './elia-issuer/elia-issuer.module';
     DIDPurposeModule,
     VcApiModule,
     DIDContactModule,
-    EliaIssuerModule
+    EliaIssuerModule,
+    IdentityHubModule
   ]
 })
 export class AppModule {}

--- a/apps/nestjs-wallet/src/identity-hub/dtos/collections-document.dto.ts
+++ b/apps/nestjs-wallet/src/identity-hub/dtos/collections-document.dto.ts
@@ -1,0 +1,5 @@
+/**
+ * Describes a document that would be used in an Identity Hub Collections request
+ * https://identity.foundation/identity-hub/spec/#collections
+ */
+export class CollectionsDocumentDto {}

--- a/apps/nestjs-wallet/src/identity-hub/dtos/collections-query-descriptor.dto.ts
+++ b/apps/nestjs-wallet/src/identity-hub/dtos/collections-query-descriptor.dto.ts
@@ -1,0 +1,13 @@
+import { IsString } from 'class-validator';
+
+/**
+ * A "CollectionsWrite" message descriptor, structed according to:
+ * https://identity.foundation/identity-hub/spec/#write-2
+ */
+export class CollectionsQueryDescriptorDto {
+  /**
+   * Schema of the data
+   */
+  @IsString()
+  schema: string;
+}

--- a/apps/nestjs-wallet/src/identity-hub/dtos/collections-query.dto.ts
+++ b/apps/nestjs-wallet/src/identity-hub/dtos/collections-query.dto.ts
@@ -1,0 +1,14 @@
+import { ValidateNested } from 'class-validator';
+import { CollectionsQueryDescriptorDto } from './collections-query-descriptor.dto';
+
+/**
+ * A "CollectionsQuery" message, structed according to:
+ * https://identity.foundation/identity-hub/spec/#query
+ */
+export class CollectionsQueryDto {
+  /**
+   * Message Descriptor
+   */
+  @ValidateNested()
+  descriptor: CollectionsQueryDescriptorDto;
+}

--- a/apps/nestjs-wallet/src/identity-hub/dtos/collections-write-descriptor.dto.ts
+++ b/apps/nestjs-wallet/src/identity-hub/dtos/collections-write-descriptor.dto.ts
@@ -1,0 +1,19 @@
+import { IsString } from 'class-validator';
+
+/**
+ * A "CollectionsWrite" message descriptor, structed according to:
+ * https://identity.foundation/identity-hub/spec/#write-2
+ */
+export class CollectionsWriteDescriptorDto {
+  /**
+   * Stringified [Version 1 CID](https://docs.ipfs.io/concepts/content-addressing/#identifier-formats) of the data associated with the message.
+   */
+  @IsString()
+  cid: string;
+
+  /**
+   * Schema of the data
+   */
+  @IsString()
+  schema: string;
+}

--- a/apps/nestjs-wallet/src/identity-hub/dtos/collections-write.dto.ts
+++ b/apps/nestjs-wallet/src/identity-hub/dtos/collections-write.dto.ts
@@ -1,0 +1,18 @@
+import { ValidateNested } from 'class-validator';
+import { CollectionsDocumentDto } from './collections-document.dto';
+import { CollectionsWriteDescriptorDto } from './collections-write-descriptor.dto';
+
+/**
+ * A "CollectionsWrite" message, structed according to:
+ * https://identity.foundation/identity-hub/spec/#write-2
+ */
+export class CollectionsWriteDto {
+  /**
+   * Data to be written
+   */
+  @ValidateNested()
+  data: CollectionsDocumentDto;
+
+  @ValidateNested()
+  descriptor: CollectionsWriteDescriptorDto;
+}

--- a/apps/nestjs-wallet/src/identity-hub/entities/collections-document.entity.ts
+++ b/apps/nestjs-wallet/src/identity-hub/entities/collections-document.entity.ts
@@ -1,0 +1,30 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+
+/**
+ * A TypeOrm entity representing a document that would be persisted to an Identity Hub collection
+ */
+@Entity()
+export class CollectionsDocumentEntity {
+  /**
+   * Document id.
+   * Expect that it be a [v1 CID](https://docs.ipfs.io/concepts/content-addressing/#identifier-formats)
+   */
+  @Column('text', { primary: true })
+  id: string;
+
+  /**
+   * The document data
+   */
+  @Column('simple-json')
+  document: Record<string, any>;
+
+  /**
+   * https://identity.foundation/identity-hub/spec/#collections
+   * "By storing data in accordance with a given schema, which may be well-known in a given vertical or industry,
+   * apps and services can leverage the same datasets across one another,
+   * enabling a cohesive, cross-platform, cross-device, cross-app experience for users."
+   * The schema can be used for querying: https://github.com/decentralized-identity/identity-hub/issues/76
+   */
+  @Column('text')
+  schema: string;
+}

--- a/apps/nestjs-wallet/src/identity-hub/identity-hub.module.ts
+++ b/apps/nestjs-wallet/src/identity-hub/identity-hub.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CollectionsDocumentEntity } from './entities/collections-document.entity';
+import { IdentityHubService } from './identity-hub.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CollectionsDocumentEntity])],
+  providers: [IdentityHubService]
+})
+export class IdentityHubModule {}

--- a/apps/nestjs-wallet/src/identity-hub/identity-hub.service.spec.ts
+++ b/apps/nestjs-wallet/src/identity-hub/identity-hub.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmSQLiteModule } from '../in-memory-db';
+import { CollectionsQueryDto } from './dtos/collections-query.dto';
+import { CollectionsWriteDto } from './dtos/collections-write.dto';
+import { CollectionsDocumentEntity } from './entities/collections-document.entity';
+import { IdentityHubService } from './identity-hub.service';
+import { calculateCID } from './ipfs-hash';
+
+describe('IdentityHubService', () => {
+  let service: IdentityHubService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TypeOrmSQLiteModule(), TypeOrmModule.forFeature([CollectionsDocumentEntity])],
+      providers: [IdentityHubService]
+    }).compile();
+
+    service = module.get<IdentityHubService>(IdentityHubService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should write and query a credential', async () => {
+    // Example credential from https://www.w3.org/TR/vc-data-model/#example-a-simple-example-of-a-verifiable-credential
+    const credential = {
+      '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/2018/credentials/examples/v1'
+      ],
+      id: 'http://example.edu/credentials/1872',
+      type: ['VerifiableCredential', 'AlumniCredential'],
+      issuer: 'https://example.edu/issuers/565049',
+      issuanceDate: '2010-01-01T19:23:24Z',
+      credentialSubject: {
+        id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+        alumniOf: {
+          id: 'did:example:c276e12ec21ebfeb1f712ebc6f1',
+          name: [
+            {
+              value: 'Example University',
+              lang: 'en'
+            },
+            {
+              value: "Exemple d'Université",
+              lang: 'fr'
+            }
+          ]
+        }
+      },
+      proof: {
+        type: 'RsaSignature2018',
+        created: '2017-06-18T21:19:10Z',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: 'https://example.edu/issuers/565049/keys/1',
+        jws: 'eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM'
+      }
+    };
+    const schema = 'https://www.w3.org/2018/credentials/examples/v1/AlumniCredential';
+    const credentialWrite = new CollectionsWriteDto();
+    credentialWrite.data = credential;
+    credentialWrite.descriptor = {
+      cid: await calculateCID(credential),
+      schema
+    };
+    const credentialQuery = new CollectionsQueryDto();
+    credentialQuery.descriptor = {
+      schema
+    };
+    await service.processCollectionsWrite(credentialWrite);
+    const queryResult = await service.processCollectionsQuery(credentialQuery);
+    expect(queryResult).toHaveLength(1);
+  });
+});

--- a/apps/nestjs-wallet/src/identity-hub/identity-hub.service.ts
+++ b/apps/nestjs-wallet/src/identity-hub/identity-hub.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CollectionsQueryDto } from './dtos/collections-query.dto';
+import { CollectionsWriteDto } from './dtos/collections-write.dto';
+import { CollectionsDocumentEntity } from './entities/collections-document.entity';
+
+@Injectable()
+export class IdentityHubService {
+  constructor(
+    @InjectRepository(CollectionsDocumentEntity)
+    private collectionsDocumentRepository: Repository<CollectionsDocumentEntity>
+  ) {}
+
+  /**
+   * Process Queries to the "Collections" interface https://identity.foundation/identity-hub/spec/#query
+   */
+  async processCollectionsQuery(queryMessage: CollectionsQueryDto): Promise<CollectionsDocumentEntity[]> {
+    const results = await this.collectionsDocumentRepository
+      .createQueryBuilder('documents')
+      .where('documents.schema = :schema', { schema: queryMessage.descriptor.schema })
+      .getMany();
+    return results;
+  }
+
+  /**
+   * Process Writes to the "Collections" interface https://identity.foundation/identity-hub/spec/#write-2
+   */
+  async processCollectionsWrite(writeMessage: CollectionsWriteDto) {
+    const collectionsDocument = this.collectionsDocumentRepository.create();
+    collectionsDocument.document = writeMessage.data;
+    collectionsDocument.id = writeMessage.descriptor.cid;
+    collectionsDocument.schema = writeMessage.descriptor.schema;
+    await this.collectionsDocumentRepository.save(collectionsDocument);
+  }
+}

--- a/apps/nestjs-wallet/src/identity-hub/ipfs-hash.ts
+++ b/apps/nestjs-wallet/src/identity-hub/ipfs-hash.ts
@@ -1,0 +1,17 @@
+import { CID } from 'multiformats/cid';
+import * as json from 'multiformats/codecs/json';
+import { sha256 } from 'multiformats/hashes/sha2';
+
+/**
+ * Trying to caculate the CID for a document
+ * https://discuss.ipfs.io/t/generate-file-hash-locally-on-browser/10607
+ * https://discuss.ipfs.io/t/manually-calculate-the-ipfs-cid-v2/11671
+ * @param document
+ * @returns CID v1
+ */
+export const calculateCID = async (document: Record<string, any>) => {
+  const bytes = json.encode({ hello: 'world' });
+  const hash = await sha256.digest(bytes);
+  const cid = CID.create(1, json.code, hash);
+  return cid.toString();
+};

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -32,6 +32,11 @@ specifiers:
   eslint-plugin-prettier: ^3.4.0
   ethers: 5.5.1
   ethr-did-resolver: ~5.0.2
+  interface-blockstore: ~2.0.2
+  interface-store: ~2.0.1
+  ipfs-core: ~0.13.0
+  ipfs-core-types: ~0.9.0
+  ipfs-unixfs-importer: ~9.0.6
   jest: 27.0.6
   jose: ^4.1.5
   prettier: ^2.3.2
@@ -46,6 +51,7 @@ specifiers:
   tsconfig-paths: ^3.10.1
   typeorm: ^0.2.38
   typescript: ^4.3.5
+  uuid: ~8.3.2
 
 dependencies:
   '@nestjs/cli': 8.1.4_eslint@7.32.0
@@ -79,6 +85,11 @@ dependencies:
   eslint-plugin-prettier: 3.4.1_6e975bd57c7acf028c1a9ddbbf60c898
   ethers: 5.5.1
   ethr-did-resolver: 5.0.2
+  interface-blockstore: 2.0.2
+  interface-store: 2.0.1
+  ipfs-core: 0.13.0
+  ipfs-core-types: 0.9.0
+  ipfs-unixfs-importer: 9.0.6
   jest: 27.0.6_ts-node@10.4.0
   jose: 4.1.5
   prettier: 2.4.1
@@ -93,8 +104,14 @@ dependencies:
   tsconfig-paths: 3.11.0
   typeorm: 0.2.38_better-sqlite3@7.4.4
   typescript: 4.4.4
+  uuid: 8.3.2
 
 packages:
+
+  /@achingbrain/node-fetch/2.6.7:
+    resolution: {integrity: sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==}
+    engines: {node: 4.x || >=6.0.0}
+    dev: false
 
   /@angular-devkit/core/12.2.10:
     resolution: {integrity: sha512-0qhmS7Qvl0hiRVTHxEC/ipFAfzYofPstw0ZITDpEMw+pgHlOZolOlnFrv8LyOXWNqlSIH5fS9D3WF7Hpm7ApYA==}
@@ -128,6 +145,10 @@ packages:
       '@angular-devkit/core': 12.2.10
       ora: 5.4.1
       rxjs: 6.6.7
+    dev: false
+
+  /@assemblyscript/loader/0.9.4:
+    resolution: {integrity: sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==}
     dev: false
 
   /@babel/code-frame/7.12.11:
@@ -574,6 +595,27 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: false
 
+  /@chainsafe/libp2p-noise/5.0.2:
+    resolution: {integrity: sha512-hpxHl3bxHN2fgpmjP2zkC2Lq3ajA349WxI7U2aBuskkq3Pd+aUmSlVjM8pyN+5Dr5+yHuayqCgMUxq3AeOM7Zw==}
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.1
+      bl: 5.0.0
+      debug: 4.3.2
+      it-buffer: 0.1.3
+      it-length-prefixed: 5.0.3
+      it-pair: 1.0.0
+      it-pb-rpc: 0.2.0
+      it-pipe: 1.1.0
+      peer-id: 0.16.0
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@cnakazawa/watch/1.0.4:
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
     engines: {node: '>=0.1.95'}
@@ -944,6 +986,41 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: false
 
+  /@ipld/car/3.2.3:
+    resolution: {integrity: sha512-pXE5mFJlXzJVaBwqAJKGlKqMmxq8H2SLEWBJgkeBDPBIN8ZbscPc3I9itkSQSlS/s6Fgx35Ri3LDTDtodQjCCQ==}
+    dependencies:
+      '@ipld/dag-cbor': 7.0.0
+      multiformats: 9.6.2
+      varint: 6.0.0
+    dev: false
+
+  /@ipld/dag-cbor/6.0.15:
+    resolution: {integrity: sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==}
+    dependencies:
+      cborg: 1.6.1
+      multiformats: 9.6.2
+    dev: false
+
+  /@ipld/dag-cbor/7.0.0:
+    resolution: {integrity: sha512-us/dagGvfQ+acO8uyAfozUQ21xxvI6ZrCWwfbOuk+o+cSpCIKY30lUYRuN3kzWLvTJHvbuCVPVEH38ynM1ZBgw==}
+    dependencies:
+      cborg: 1.6.1
+      multiformats: 9.6.2
+    dev: false
+
+  /@ipld/dag-json/8.0.7:
+    resolution: {integrity: sha512-nG4hdl1V4GDKZ6Mumu2tL8zSpem/lRSVpQOd1uEovF+qPRkVnb06hsETy97J3kR0EjbZgge8m5AYtrab3DSREg==}
+    dependencies:
+      cborg: 1.6.1
+      multiformats: 9.6.2
+    dev: false
+
+  /@ipld/dag-pb/2.1.15:
+    resolution: {integrity: sha512-qkoUIiuQDx2ZN+YmYFdSNNHRt15p1XTYbqsseb8DgA0ACcqCUurbiNVd0jt5GuiBm76t2mOV2cZsNu6rykRFBQ==}
+    dependencies:
+      multiformats: 9.6.2
+    dev: false
+
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -1185,6 +1262,10 @@ packages:
       chalk: 4.1.2
     dev: false
 
+  /@leichtgewicht/ip-codec/2.0.3:
+    resolution: {integrity: sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==}
+    dev: false
+
   /@microsoft/tsdoc-config/0.15.2:
     resolution: {integrity: sha512-mK19b2wJHSdNf8znXSMYVShAHktVr/ib0Ck2FA3lsVBSEhSI/TfXT7DJQkAYgcztTuwazGcg58ZjYdk0hTCVrA==}
     dependencies:
@@ -1196,6 +1277,13 @@ packages:
 
   /@microsoft/tsdoc/0.13.2:
     resolution: {integrity: sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==}
+    dev: false
+
+  /@multiformats/murmur3/1.0.8:
+    resolution: {integrity: sha512-neeqwdZ7CmvNQEr+M7mFIC71Wy+SI2dxoOGm5eFpA0Jw7bMaoOXsOhY21JeFVScPlRi1t5+6UF3/nzfdMvOGlw==}
+    dependencies:
+      multiformats: 9.6.2
+      murmurhash3js-revisited: 3.0.0
     dev: false
 
   /@nestjs/cli/8.1.4_eslint@7.32.0:
@@ -1429,6 +1517,14 @@ packages:
       uuid: 8.3.2
     dev: false
 
+  /@noble/ed25519/1.5.1:
+    resolution: {integrity: sha512-VX0TyIhKghm/NoTno/k71oCQO55f36yiSwuNOqEHu9BvxQuzel0tsvcsU2KjX/iN6pCkN53Bvfq1+gWNiwXDGQ==}
+    dev: false
+
+  /@noble/secp256k1/1.5.1:
+    resolution: {integrity: sha512-KJJ36KR3VAxo4TbpjcDGLXx1/Z4AzUIdxs/3QDOG8TtNuDBUVz7KYDpV+qK/ClBkOPFAPfOzrIsI1/ulAkmHag==}
+    dev: false
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1458,6 +1554,49 @@ packages:
       chalk: 4.1.2
       consola: 2.15.3
       node-fetch: 2.6.6
+    dev: false
+
+  /@protobufjs/aspromise/1.1.2:
+    resolution: {integrity: sha1-m4sMxmPWaafY9vXQiToU00jzD78=}
+    dev: false
+
+  /@protobufjs/base64/1.1.2:
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    dev: false
+
+  /@protobufjs/codegen/2.0.4:
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    dev: false
+
+  /@protobufjs/eventemitter/1.1.0:
+    resolution: {integrity: sha1-NVy8mLr61ZePntCV85diHx0Ga3A=}
+    dev: false
+
+  /@protobufjs/fetch/1.1.0:
+    resolution: {integrity: sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=}
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+    dev: false
+
+  /@protobufjs/float/1.0.2:
+    resolution: {integrity: sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=}
+    dev: false
+
+  /@protobufjs/inquire/1.1.0:
+    resolution: {integrity: sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=}
+    dev: false
+
+  /@protobufjs/path/1.1.2:
+    resolution: {integrity: sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=}
+    dev: false
+
+  /@protobufjs/pool/1.1.0:
+    resolution: {integrity: sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=}
+    dev: false
+
+  /@protobufjs/utf8/1.1.0:
+    resolution: {integrity: sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=}
     dev: false
 
   /@rushstack/eslint-config/2.3.4_eslint@7.32.0+typescript@4.4.4:
@@ -1542,6 +1681,15 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: false
 
+  /@socket.io/base64-arraybuffer/1.0.2:
+    resolution: {integrity: sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
+  /@socket.io/component-emitter/3.0.0:
+    resolution: {integrity: sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==}
+    dev: false
+
   /@spruceid/didkit-wasm-node/0.1.6:
     resolution: {integrity: sha512-8+NDgNCDLvNf142Up7DKZLqG04G6soiFoMw8ZX3U4pVyu2r3GPWP2Dc3sPGMF+8Aegoe6GbVT3gZjCFoKMt4bw==}
     dev: false
@@ -1552,6 +1700,106 @@ packages:
 
   /@sqltools/formatter/1.2.3:
     resolution: {integrity: sha512-O3uyB/JbkAEMZaP3YqyHH7TMnex7tWyCbCI4EfJdOCoN6HIhqdJBWTM6aCCiWQ/5f5wxjgU735QAIpJbjDvmzg==}
+    dev: false
+
+  /@stablelib/aead/1.0.1:
+    resolution: {integrity: sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==}
+    dev: false
+
+  /@stablelib/binary/1.0.1:
+    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
+    dependencies:
+      '@stablelib/int': 1.0.1
+    dev: false
+
+  /@stablelib/bytes/1.0.1:
+    resolution: {integrity: sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==}
+    dev: false
+
+  /@stablelib/chacha/1.0.1:
+    resolution: {integrity: sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==}
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/chacha20poly1305/1.0.1:
+    resolution: {integrity: sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==}
+    dependencies:
+      '@stablelib/aead': 1.0.1
+      '@stablelib/binary': 1.0.1
+      '@stablelib/chacha': 1.0.1
+      '@stablelib/constant-time': 1.0.1
+      '@stablelib/poly1305': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/constant-time/1.0.1:
+    resolution: {integrity: sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==}
+    dev: false
+
+  /@stablelib/hash/1.0.1:
+    resolution: {integrity: sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==}
+    dev: false
+
+  /@stablelib/hkdf/1.0.1:
+    resolution: {integrity: sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==}
+    dependencies:
+      '@stablelib/hash': 1.0.1
+      '@stablelib/hmac': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/hmac/1.0.1:
+    resolution: {integrity: sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==}
+    dependencies:
+      '@stablelib/constant-time': 1.0.1
+      '@stablelib/hash': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/int/1.0.1:
+    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
+    dev: false
+
+  /@stablelib/keyagreement/1.0.1:
+    resolution: {integrity: sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==}
+    dependencies:
+      '@stablelib/bytes': 1.0.1
+    dev: false
+
+  /@stablelib/poly1305/1.0.1:
+    resolution: {integrity: sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==}
+    dependencies:
+      '@stablelib/constant-time': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/random/1.0.1:
+    resolution: {integrity: sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==}
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/sha256/1.0.1:
+    resolution: {integrity: sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==}
+    dependencies:
+      '@stablelib/binary': 1.0.1
+      '@stablelib/hash': 1.0.1
+      '@stablelib/wipe': 1.0.1
+    dev: false
+
+  /@stablelib/wipe/1.0.1:
+    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
+    dev: false
+
+  /@stablelib/x25519/1.0.1:
+    resolution: {integrity: sha512-nmyUI2ZArxYDh1PhdoSCPEtlTYE0DYugp2qqx8OtjrX3Hmh7boIlDsD0X71ihAxzxqJf3TyQqN/p58ToWhnp+Q==}
+    dependencies:
+      '@stablelib/keyagreement': 1.0.1
+      '@stablelib/random': 1.0.1
+      '@stablelib/wipe': 1.0.1
     dev: false
 
   /@tootallnate/once/1.1.2:
@@ -1627,6 +1875,12 @@ packages:
 
   /@types/cookiejar/2.1.2:
     resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
+    dev: false
+
+  /@types/debug/4.1.7:
+    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+    dependencies:
+      '@types/ms': 0.7.31
     dev: false
 
   /@types/eslint-scope/3.7.1:
@@ -1705,8 +1959,20 @@ packages:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
     dev: false
 
+  /@types/long/4.0.1:
+    resolution: {integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==}
+    dev: false
+
   /@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
+    dev: false
+
+  /@types/minimatch/3.0.5:
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
+    dev: false
+
+  /@types/ms/0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: false
 
   /@types/node/16.11.6:
@@ -1727,6 +1993,10 @@ packages:
 
   /@types/range-parser/1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
+    dev: false
+
+  /@types/retry/0.12.1:
+    resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
     dev: false
 
   /@types/serve-static/1.13.10:
@@ -2015,6 +2285,10 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: false
 
+  /@vascosantos/moving-average/1.1.0:
+    resolution: {integrity: sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w==}
+    dev: false
+
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
     dependencies:
@@ -2133,6 +2407,31 @@ packages:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: false
 
+  /abort-controller/3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
+
+  /abortable-iterator/3.0.2:
+    resolution: {integrity: sha512-qVP8HFfTpUQI2F+f1tpTriKDIZ4XrmwCrBCrQeRKO7DKWF3kgoT6NXiNDv2krrGcHxPwmI63eGQiec81sEaWIw==}
+    dependencies:
+      get-iterator: 1.0.2
+    dev: false
+
+  /abstract-leveldown/7.2.0:
+    resolution: {integrity: sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      buffer: 6.0.3
+      catering: 2.1.1
+      is-buffer: 2.0.5
+      level-concat-iterator: 3.1.0
+      level-supports: 2.1.0
+      queue-microtask: 1.2.3
+    dev: false
+
   /accepts/1.3.7:
     resolution: {integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==}
     engines: {node: '>= 0.6'}
@@ -2197,6 +2496,14 @@ packages:
       debug: 4.3.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /aggregate-error/3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
     dev: false
 
   /ajv-formats/2.1.0:
@@ -2293,6 +2600,17 @@ packages:
     resolution: {integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=}
     dev: false
 
+  /any-signal/2.1.2:
+    resolution: {integrity: sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==}
+    dependencies:
+      abort-controller: 3.0.0
+      native-abort-controller: 1.0.4_abort-controller@3.0.0
+    dev: false
+
+  /any-signal/3.0.0:
+    resolution: {integrity: sha512-l1H1GEkGGIXVGfCtvq8N68YI7gHajmfzRdKhmb8sGyAQpLCblirLa8eB09j4uKaiwe7vodAChocUf7AT3mYq5g==}
+    dev: false
+
   /anymatch/2.0.0:
     resolution: {integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==}
     dependencies:
@@ -2372,6 +2690,11 @@ packages:
       is-string: 1.0.7
     dev: false
 
+  /array-shuffle/2.0.0:
+    resolution: {integrity: sha512-rJTchCppiO6QsQnN51KDH1cgMYm13B+ybxFS5GgdBdTTHpZcrq3M7SOBgzp+L9fqqnjkFDiwdEVcX1wINgl9DQ==}
+    engines: {node: '>=10'}
+    dev: false
+
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -2400,6 +2723,17 @@ packages:
       safer-buffer: 2.1.2
     dev: false
 
+  /asn1/0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /assert-plus/1.0.0:
+    resolution: {integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=}
+    engines: {node: '>=0.8'}
+    dev: false
+
   /assign-symbols/1.0.0:
     resolution: {integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=}
     engines: {node: '>=0.10.0'}
@@ -2408,6 +2742,10 @@ packages:
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+    dev: false
+
+  /async/3.2.3:
+    resolution: {integrity: sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==}
     dev: false
 
   /asynckit/0.4.0:
@@ -2423,6 +2761,14 @@ packages:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
     engines: {node: '>= 4.5.0'}
     hasBin: true
+    dev: false
+
+  /aws-sign2/0.7.0:
+    resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}
+    dev: false
+
+  /aws4/1.11.0:
+    resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: false
 
   /axios/0.23.0:
@@ -2563,6 +2909,10 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.0
     dev: false
 
+  /backo2/1.0.2:
+    resolution: {integrity: sha1-MasayLEpNjRj41s+u2n038+6eUc=}
+    dev: false
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
@@ -2602,6 +2952,12 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
+  /bcrypt-pbkdf/1.0.2:
+    resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
+    dependencies:
+      tweetnacl: 0.14.5
+    dev: false
+
   /bech32/1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
     dev: false
@@ -2613,6 +2969,10 @@ packages:
       bindings: 1.5.0
       prebuild-install: 6.1.4
       tar: 6.1.11
+    dev: false
+
+  /bignumber.js/9.0.2:
+    resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==}
     dev: false
 
   /binary-extensions/2.2.0:
@@ -2632,6 +2992,45 @@ packages:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.0
+    dev: false
+
+  /bl/5.0.0:
+    resolution: {integrity: sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==}
+    dependencies:
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
+  /blob-to-it/1.0.4:
+    resolution: {integrity: sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==}
+    dependencies:
+      browser-readablestream-to-it: 1.0.3
+    dev: false
+
+  /blockstore-core/1.0.5:
+    resolution: {integrity: sha512-i/9CUMMvBALVbtSqUIuiWB3tk//a4Q2I2CEWiBuYNnhJvk/DWplXjLt8Sqc5VGkRVXVPSsEuH8fUtqJt5UFYcA==}
+    dependencies:
+      err-code: 3.0.1
+      interface-blockstore: 2.0.2
+      interface-store: 2.0.1
+      it-all: 1.0.6
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-take: 1.0.2
+      multiformats: 9.6.2
+    dev: false
+
+  /blockstore-datastore-adapter/2.0.3:
+    resolution: {integrity: sha512-s6j6ay+qLu7sOx5DanHJlg2dBX61B9Yrbg6qo8oP3oiWnj6ZFCad4CKVb8do1f4u/Q4r2XPuSM4JYCe684USrQ==}
+    dependencies:
+      blockstore-core: 1.0.5
+      err-code: 3.0.1
+      interface-blockstore: 2.0.2
+      interface-datastore: 6.0.3
+      it-drain: 1.0.5
+      it-pushable: 1.4.2
+      multiformats: 9.6.2
     dev: false
 
   /bn.js/4.12.0:
@@ -2690,6 +3089,10 @@ packages:
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
+    dev: false
+
+  /browser-readablestream-to-it/1.0.3:
+    resolution: {integrity: sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==}
     dev: false
 
   /browserslist/4.17.6:
@@ -2802,6 +3205,20 @@ packages:
       rsvp: 4.8.5
     dev: false
 
+  /caseless/0.12.0:
+    resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
+    dev: false
+
+  /catering/2.1.1:
+    resolution: {integrity: sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /cborg/1.6.1:
+    resolution: {integrity: sha512-dOGlTG610S6t3j7EYFxPBH7KiF1OlSAdWtMI4Iv1dabcId/L/nUvkfOEPge+vDp9YoPerEMiDoy5+Vm2oEqmQw==}
+    hasBin: true
+    dev: false
+
   /chalk/1.1.3:
     resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
     engines: {node: '>=0.10.0'}
@@ -2888,6 +3305,10 @@ packages:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: false
 
+  /class-is/1.1.0:
+    resolution: {integrity: sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==}
+    dev: false
+
   /class-transformer/0.4.0:
     resolution: {integrity: sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==}
     dev: false
@@ -2908,6 +3329,11 @@ packages:
       '@types/validator': 13.6.6
       libphonenumber-js: 1.9.42
       validator: 13.7.0
+    dev: false
+
+  /clean-stack/2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
     dev: false
 
   /cli-cursor/3.1.0:
@@ -3090,6 +3516,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /core-util-is/1.0.2:
+    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
+    dev: false
+
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
@@ -3169,6 +3599,13 @@ packages:
       cssom: 0.3.8
     dev: false
 
+  /dashdash/1.14.1:
+    resolution: {integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=}
+    engines: {node: '>=0.10'}
+    dependencies:
+      assert-plus: 1.0.0
+    dev: false
+
   /data-urls/2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
@@ -3176,6 +3613,65 @@ packages:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
+    dev: false
+
+  /datastore-core/6.0.7:
+    resolution: {integrity: sha512-y+RfRV3FXZK2kpHTwuoyIod3mHtleW/tDx5ilsn9cdIflxQb5rWrRc3GzRwPOnq2oEtN1W019BZOwC5h6p6g6Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      debug: 4.3.2
+      err-code: 3.0.1
+      interface-datastore: 6.0.3
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-map: 1.0.6
+      it-merge: 1.0.4
+      it-pipe: 1.1.0
+      it-pushable: 1.4.2
+      it-take: 1.0.2
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /datastore-fs/6.0.1:
+    resolution: {integrity: sha512-A0JTQx6LV91ddCdnFLFES5k4stJahfz8GwpnXdMSuZLcrP1Fwa/vcnKAdRlvXpJY83Gl3+skbjh0nV5LNy1w1w==}
+    dependencies:
+      datastore-core: 6.0.7
+      fast-write-atomic: 0.2.1
+      interface-datastore: 6.0.3
+      it-glob: 1.0.2
+      it-map: 1.0.6
+      it-parallel-batch: 1.0.10
+      mkdirp: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /datastore-level/7.0.1:
+    resolution: {integrity: sha512-UCLOwKloaLYrcWVewSCOqVWEHUxz1PijsWHrI0dPZd3kODSWLSpW5CYylkWKPTX+JM7S1wENbiaz3i1188JXig==}
+    dependencies:
+      datastore-core: 6.0.7
+      interface-datastore: 6.0.3
+      it-filter: 1.0.3
+      it-map: 1.0.6
+      it-sort: 1.0.1
+      it-take: 1.0.2
+      level: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /datastore-pubsub/1.0.0:
+    resolution: {integrity: sha512-L2S3avrrOJUsApahmObTxUgepe+BcZzqo4svKDqcRZ8zZZj+RH/q9iJnr89kKs/6Rpidg/FLyV58jxQ8DiZ5Pg==}
+    dependencies:
+      datastore-core: 6.0.7
+      debug: 4.3.2
+      err-code: 3.0.1
+      interface-datastore: 6.0.3
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /debug/2.6.9:
@@ -3230,10 +3726,25 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /default-gateway/6.0.3:
+    resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
+    engines: {node: '>= 10'}
+    dependencies:
+      execa: 5.1.1
+    dev: false
+
   /defaults/1.0.3:
     resolution: {integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=}
     dependencies:
       clone: 1.0.4
+    dev: false
+
+  /deferred-leveldown/7.0.0:
+    resolution: {integrity: sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==}
+    engines: {node: '>=10'}
+    dependencies:
+      abstract-leveldown: 7.2.0
+      inherits: 2.0.4
     dev: false
 
   /define-properties/1.1.3:
@@ -3272,6 +3783,11 @@ packages:
 
   /delegates/1.0.0:
     resolution: {integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=}
+    dev: false
+
+  /denque/1.5.1:
+    resolution: {integrity: sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==}
+    engines: {node: '>=0.10'}
     dev: false
 
   /depd/1.1.2:
@@ -3338,6 +3854,28 @@ packages:
       path-type: 4.0.0
     dev: false
 
+  /dlv/1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: false
+
+  /dns-over-http-resolver/1.2.3:
+    resolution: {integrity: sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==}
+    dependencies:
+      debug: 4.3.2
+      native-fetch: 3.0.0
+      receptacle: 1.3.2
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /dns-packet/5.3.1:
+    resolution: {integrity: sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@leichtgewicht/ip-codec': 2.0.3
+    dev: false
+
   /doctrine/2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -3373,6 +3911,13 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /ecc-jsbn/0.1.2:
+    resolution: {integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=}
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+    dev: false
+
   /ed2curve/0.2.1:
     resolution: {integrity: sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=}
     dependencies:
@@ -3381,6 +3926,13 @@ packages:
 
   /ee-first/1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    dev: false
+
+  /electron-fetch/1.7.4:
+    resolution: {integrity: sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==}
+    engines: {node: '>=6'}
+    dependencies:
+      encoding: 0.1.13
     dev: false
 
   /electron-to-chromium/1.3.890:
@@ -3413,10 +3965,51 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /encoding-down/7.1.0:
+    resolution: {integrity: sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      abstract-leveldown: 7.2.0
+      inherits: 2.0.4
+      level-codec: 10.0.0
+      level-errors: 3.0.1
+    dev: false
+
+  /encoding/0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: false
+
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
+    dev: false
+
+  /engine.io-client/6.1.1:
+    resolution: {integrity: sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==}
+    dependencies:
+      '@socket.io/component-emitter': 3.0.0
+      debug: 4.3.2
+      engine.io-parser: 5.0.3
+      has-cors: 1.1.0
+      parseqs: 0.0.6
+      parseuri: 0.0.6
+      ws: 8.2.3
+      xmlhttprequest-ssl: 2.0.0
+      yeast: 0.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /engine.io-parser/5.0.3:
+    resolution: {integrity: sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/base64-arraybuffer': 1.0.2
     dev: false
 
   /enhanced-resolve/5.8.3:
@@ -3432,6 +4025,14 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
+    dev: false
+
+  /err-code/2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+    dev: false
+
+  /err-code/3.0.1:
+    resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
     dev: false
 
   /error-ex/1.3.2:
@@ -3477,6 +4078,11 @@ packages:
       is-callable: 1.2.4
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+    dev: false
+
+  /es6-promisify/7.0.0:
+    resolution: {integrity: sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==}
+    engines: {node: '>=6'}
     dev: false
 
   /escalade/3.1.1:
@@ -3773,6 +4379,19 @@ packages:
       - utf-8-validate
     dev: false
 
+  /event-iterator/2.0.0:
+    resolution: {integrity: sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==}
+    dev: false
+
+  /event-target-shim/5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /eventemitter3/4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
   /events/3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -3911,6 +4530,10 @@ packages:
       is-extendable: 1.0.1
     dev: false
 
+  /extend/3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /external-editor/3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -3934,12 +4557,21 @@ packages:
       to-regex: 3.0.2
     dev: false
 
+  /extsprintf/1.3.0:
+    resolution: {integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=}
+    engines: {'0': node >=0.6.0}
+    dev: false
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
 
   /fast-diff/1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
+    dev: false
+
+  /fast-fifo/1.1.0:
+    resolution: {integrity: sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g==}
     dev: false
 
   /fast-glob/3.2.7:
@@ -3963,6 +4595,10 @@ packages:
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
+
+  /fast-write-atomic/0.2.1:
+    resolution: {integrity: sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw==}
     dev: false
 
   /fastq/1.13.0:
@@ -4050,6 +4686,10 @@ packages:
     resolution: {integrity: sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==}
     dev: false
 
+  /fnv1a/1.0.1:
+    resolution: {integrity: sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=}
+    dev: false
+
   /follow-redirects/1.14.5:
     resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
     engines: {node: '>=4.0'}
@@ -4063,6 +4703,10 @@ packages:
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /forever-agent/0.6.1:
+    resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
   /fork-ts-checker-webpack-plugin/6.3.4_1f87f326394b27519d7e15067f373e2e:
@@ -4095,6 +4739,15 @@ packages:
       tapable: 1.1.3
       typescript: 4.3.5
       webpack: 5.58.2
+    dev: false
+
+  /form-data/2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.33
     dev: false
 
   /form-data/3.0.1:
@@ -4199,6 +4852,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
+  /get-browser-rtc/1.1.0:
+    resolution: {integrity: sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==}
+    dev: false
+
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -4210,6 +4867,10 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.2
+    dev: false
+
+  /get-iterator/1.0.2:
+    resolution: {integrity: sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==}
     dev: false
 
   /get-package-type/0.1.0:
@@ -4247,6 +4908,12 @@ packages:
   /get-value/2.0.6:
     resolution: {integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /getpass/0.1.7:
+    resolution: {integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=}
+    dependencies:
+      assert-plus: 1.0.0
     dev: false
 
   /github-from-package/0.0.0:
@@ -4303,6 +4970,28 @@ packages:
     resolution: {integrity: sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==}
     dev: false
 
+  /hamt-sharding/2.0.1:
+    resolution: {integrity: sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==}
+    engines: {node: '>=10.0.0', npm: '>=6.0.0'}
+    dependencies:
+      sparse-array: 1.3.2
+      uint8arrays: 3.0.0
+    dev: false
+
+  /har-schema/2.0.0:
+    resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
+    engines: {node: '>=4'}
+    dev: false
+
+  /har-validator/5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+    dependencies:
+      ajv: 6.12.6
+      har-schema: 2.0.0
+    dev: false
+
   /has-ansi/2.0.0:
     resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
     engines: {node: '>=0.10.0'}
@@ -4312,6 +5001,10 @@ packages:
 
   /has-bigints/1.0.1:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
+    dev: false
+
+  /has-cors/1.1.0:
+    resolution: {integrity: sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=}
     dev: false
 
   /has-flag/3.0.0:
@@ -4385,6 +5078,10 @@ packages:
       minimalistic-assert: 1.0.1
     dev: false
 
+  /hashlru/2.3.0:
+    resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
+    dev: false
+
   /highlight.js/10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: false
@@ -4441,6 +5138,15 @@ packages:
       - supports-color
     dev: false
 
+  /http-signature/1.2.0:
+    resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.17.0
+    dev: false
+
   /https-proxy-agent/5.0.0:
     resolution: {integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==}
     engines: {node: '>= 6'}
@@ -4463,6 +5169,13 @@ packages:
 
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /iconv-lite/0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
@@ -4502,6 +5215,11 @@ packages:
   /imurmurhash/0.1.4:
     resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
     engines: {node: '>=0.8.19'}
+    dev: false
+
+  /indent-string/4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
     dev: false
 
   /inflight/1.0.6:
@@ -4562,6 +5280,41 @@ packages:
       through: 2.3.8
     dev: false
 
+  /interface-blockstore/1.0.2:
+    resolution: {integrity: sha512-e8rHqaBSOsBPpSaB+wwVa9mR5ntU+t1yzXpOFC16cSKCNsV+h6n8SjekPQcdODVBN2h8t45CsOqRAnUfm1guEw==}
+    dependencies:
+      err-code: 3.0.1
+      interface-store: 1.0.2
+      it-all: 1.0.6
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-take: 1.0.2
+      multiformats: 9.6.2
+    dev: false
+
+  /interface-blockstore/2.0.2:
+    resolution: {integrity: sha512-2OonKanTF7xnlqe879EgYwv94e7jYO20dDMyqkDum7b9RnhdMkiLAOkeStlvxX1sZBLjcThyHzFTUYTK4ohKpg==}
+    dependencies:
+      interface-store: 2.0.1
+      multiformats: 9.6.2
+    dev: false
+
+  /interface-datastore/6.0.3:
+    resolution: {integrity: sha512-61eOyzh7zH1ks/56hPudW6pbqsOdoHSYMVjuqlIlZGjyg0svR6DHlCcaeSJfWW8t6dsPl1n7qKBdk8ZqPzXuLA==}
+    dependencies:
+      interface-store: 2.0.1
+      nanoid: 3.2.0
+      uint8arrays: 3.0.0
+    dev: false
+
+  /interface-store/1.0.2:
+    resolution: {integrity: sha512-rUBLYsgoWwxuUpnQoSUr+DR/3dH3reVeIu5aOHFZK31lAexmb++kR6ZECNRgrx6WvoaM3Akdo0A7TDrqgCzZaQ==}
+    dev: false
+
+  /interface-store/2.0.1:
+    resolution: {integrity: sha512-TfjYMdk4RlaGPA0VGk8fVPM+xhFbjiA2mTv1AqhiFh3N+ZEwoJnmDu/EBdKXzl80nyd0pvKui3RTC3zFgHMjTA==}
+    dev: false
+
   /internal-slot/1.0.3:
     resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
     engines: {node: '>= 0.4'}
@@ -4576,9 +5329,367 @@ packages:
     engines: {node: '>= 0.10'}
     dev: false
 
+  /ip-address/8.1.0:
+    resolution: {integrity: sha512-Wz91gZKpNKoXtqvY8ScarKYwhXoK4r/b5QuT+uywe/azv0/nUCo7Bh0IRRI7F9DHR06kJNWtzMGLIbXavngbKA==}
+    engines: {node: '>= 12'}
+    dependencies:
+      jsbn: 1.1.0
+      sprintf-js: 1.1.2
+    dev: false
+
+  /ip-regex/4.3.0:
+    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
+    engines: {node: '>=8'}
+    dev: false
+
   /ipaddr.js/1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /ipaddr.js/2.0.1:
+    resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
+    engines: {node: '>= 10'}
+    dev: false
+
+  /ipfs-bitswap/9.0.0:
+    resolution: {integrity: sha512-NtqLTr5+a0moZ+Hw9Px9Z+pXHR7Lt/48oQaphA0n2POFOb3//sViJR/7pe/IFHqFkgpL+iygYsE/uIhNateQ4g==}
+    dependencies:
+      '@vascosantos/moving-average': 1.1.0
+      abort-controller: 3.0.0
+      any-signal: 2.1.2
+      blockstore-core: 1.0.5
+      debug: 4.3.2
+      err-code: 3.0.1
+      interface-blockstore: 2.0.2
+      it-length-prefixed: 5.0.3
+      it-pipe: 1.1.0
+      just-debounce-it: 1.5.0
+      libp2p-interfaces: 2.0.9
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      native-abort-controller: 1.0.4_abort-controller@3.0.0
+      protobufjs: 6.11.2
+      readable-stream: 3.6.0
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+      varint-decoder: 1.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /ipfs-core-config/0.2.0:
+    resolution: {integrity: sha512-vfVfubpwGq71teJ135Tv1IZuhDxypsv1ETOFTGYzEqH3VzpRaYoAil3UIJHTg0LV4gs3QOTfZKFfyNhY642FNw==}
+    dependencies:
+      '@chainsafe/libp2p-noise': 5.0.2
+      blockstore-datastore-adapter: 2.0.3
+      datastore-core: 6.0.7
+      datastore-fs: 6.0.1
+      datastore-level: 7.0.1
+      debug: 4.3.2
+      err-code: 3.0.1
+      hashlru: 2.3.0
+      ipfs-repo: 13.0.7
+      ipfs-utils: 9.0.4
+      ipns: 0.16.0
+      is-ipfs: 6.0.2
+      it-all: 1.0.6
+      it-drain: 1.0.5
+      libp2p-floodsub: 0.28.0
+      libp2p-gossipsub: 0.12.3
+      libp2p-kad-dht: 0.27.6
+      libp2p-mdns: 0.18.0
+      libp2p-mplex: 0.10.7
+      libp2p-tcp: 0.17.2
+      libp2p-webrtc-star: 0.25.0
+      libp2p-websockets: 0.16.2
+      p-queue: 6.6.2
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - abort-controller
+      - bufferutil
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /ipfs-core-types/0.9.0:
+    resolution: {integrity: sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==}
+    dependencies:
+      interface-datastore: 6.0.3
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /ipfs-core-utils/0.13.0:
+    resolution: {integrity: sha512-HP5EafxU4/dLW3U13CFsgqVO5Ika8N4sRSIb/dTg16NjLOozMH31TXV0Grtu2ZWo1T10ahTzMvrfT5f4mhioXw==}
+    dependencies:
+      any-signal: 2.1.2
+      blob-to-it: 1.0.4
+      browser-readablestream-to-it: 1.0.3
+      debug: 4.3.2
+      err-code: 3.0.1
+      ipfs-core-types: 0.9.0
+      ipfs-unixfs: 6.0.6
+      ipfs-utils: 9.0.4
+      it-all: 1.0.6
+      it-map: 1.0.6
+      it-peekable: 1.0.3
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      multiaddr: 10.0.1
+      multiaddr-to-uri: 8.0.0
+      multiformats: 9.6.2
+      nanoid: 3.2.0
+      parse-duration: 1.0.2
+      timeout-abort-controller: 2.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /ipfs-core/0.13.0:
+    resolution: {integrity: sha512-25spsvgiRYle1QCC5Fzw4or/Rt1hAy7oZapL+mxXbweYL7JCX5AVYQZ8ypZbME0NQq8M6NDZ+IISwmr/wmAetQ==}
+    dependencies:
+      '@chainsafe/libp2p-noise': 5.0.2
+      '@ipld/car': 3.2.3
+      '@ipld/dag-cbor': 7.0.0
+      '@ipld/dag-json': 8.0.7
+      '@ipld/dag-pb': 2.1.15
+      '@multiformats/murmur3': 1.0.8
+      any-signal: 2.1.2
+      array-shuffle: 2.0.0
+      blockstore-core: 1.0.5
+      blockstore-datastore-adapter: 2.0.3
+      datastore-core: 6.0.7
+      datastore-pubsub: 1.0.0
+      debug: 4.3.2
+      dlv: 1.1.3
+      err-code: 3.0.1
+      hamt-sharding: 2.0.1
+      hashlru: 2.3.0
+      interface-blockstore: 2.0.2
+      interface-datastore: 6.0.3
+      ipfs-bitswap: 9.0.0
+      ipfs-core-config: 0.2.0
+      ipfs-core-types: 0.9.0
+      ipfs-core-utils: 0.13.0
+      ipfs-http-client: 55.0.0
+      ipfs-repo: 13.0.7
+      ipfs-unixfs: 6.0.6
+      ipfs-unixfs-exporter: 7.0.6
+      ipfs-unixfs-importer: 9.0.6
+      ipfs-utils: 9.0.4
+      ipns: 0.16.0
+      is-domain-name: 1.0.1
+      is-ipfs: 6.0.2
+      it-all: 1.0.6
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-first: 1.0.7
+      it-last: 1.0.6
+      it-map: 1.0.6
+      it-merge: 1.0.4
+      it-parallel: 2.0.1
+      it-peekable: 1.0.3
+      it-pipe: 1.1.0
+      it-pushable: 1.4.2
+      it-tar: 4.0.0
+      it-to-buffer: 2.0.2
+      just-safe-set: 2.2.3
+      libp2p: 0.35.8
+      libp2p-bootstrap: 0.14.0
+      libp2p-crypto: 0.21.2
+      libp2p-delegated-content-routing: 0.11.2
+      libp2p-delegated-peer-routing: 0.11.1
+      libp2p-record: 0.10.6
+      mafmt: 10.0.0
+      merge-options: 3.0.4
+      mortice: 2.0.1
+      multiaddr: 10.0.1
+      multiaddr-to-uri: 8.0.0
+      multiformats: 9.6.2
+      native-abort-controller: 1.0.4
+      pako: 1.0.11
+      parse-duration: 1.0.2
+      peer-id: 0.16.0
+      timeout-abort-controller: 2.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - abort-controller
+      - bufferutil
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /ipfs-http-client/55.0.0:
+    resolution: {integrity: sha512-GpvEs7C7WL9M6fN/kZbjeh4Y8YN7rY8b18tVWZnKxRsVwM25cIFrRI8CwNt3Ugin9yShieI3i9sPyzYGMrLNnQ==}
+    engines: {node: '>=14.0.0', npm: '>=3.0.0'}
+    dependencies:
+      '@ipld/dag-cbor': 7.0.0
+      '@ipld/dag-json': 8.0.7
+      '@ipld/dag-pb': 2.1.15
+      abort-controller: 3.0.0
+      any-signal: 2.1.2
+      debug: 4.3.2
+      err-code: 3.0.1
+      ipfs-core-types: 0.9.0
+      ipfs-core-utils: 0.13.0
+      ipfs-utils: 9.0.4
+      it-first: 1.0.7
+      it-last: 1.0.6
+      merge-options: 3.0.4
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      native-abort-controller: 1.0.4_abort-controller@3.0.0
+      parse-duration: 1.0.2
+      stream-to-it: 0.2.4
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /ipfs-repo-migrations/11.0.2:
+    resolution: {integrity: sha512-0+O1q3X06jObIKYIEyUDNH1078PrQ7qg4i3Ufv4U0+R4MlF1LOYyQGwW6AK87V94Pta0bHeicYeY3dGpGgzv4g==}
+    dependencies:
+      '@ipld/dag-pb': 2.1.15
+      cborg: 1.6.1
+      datastore-core: 6.0.7
+      debug: 4.3.2
+      fnv1a: 1.0.1
+      interface-blockstore: 2.0.2
+      interface-datastore: 6.0.3
+      it-length: 1.0.4
+      multiformats: 9.6.2
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ipfs-repo/13.0.7:
+    resolution: {integrity: sha512-0z3iApJMew2XM8ZeAPDUnEOII10s+LNThd/jmiLvkRPcMVAkzsyRXpWnRQ2hPuDGxw91QCcQHG+GS4xW2eVCdQ==}
+    dependencies:
+      '@ipld/dag-pb': 2.1.15
+      bytes: 3.1.0
+      cborg: 1.6.1
+      datastore-core: 6.0.7
+      debug: 4.3.2
+      err-code: 3.0.1
+      interface-blockstore: 2.0.2
+      interface-datastore: 6.0.3
+      ipfs-repo-migrations: 11.0.2
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-first: 1.0.7
+      it-map: 1.0.6
+      it-merge: 1.0.4
+      it-parallel-batch: 1.0.10
+      it-pipe: 1.1.0
+      it-pushable: 1.4.2
+      just-safe-get: 2.1.2
+      just-safe-set: 2.2.3
+      merge-options: 3.0.4
+      mortice: 2.0.1
+      multiformats: 9.6.2
+      p-queue: 6.6.2
+      proper-lockfile: 4.1.2
+      sort-keys: 4.2.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ipfs-unixfs-exporter/7.0.6:
+    resolution: {integrity: sha512-PkKB+hTbHhKLqgj0PqSNQ/n7dKsu/lC29jLK8nUXOX4EM6c+RnedohdCY7khT10/hfC7oADbpFs/QJfuH2DaAg==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dependencies:
+      '@ipld/dag-cbor': 6.0.15
+      '@ipld/dag-pb': 2.1.15
+      '@multiformats/murmur3': 1.0.8
+      err-code: 3.0.1
+      hamt-sharding: 2.0.1
+      interface-blockstore: 1.0.2
+      ipfs-unixfs: 6.0.6
+      it-last: 1.0.6
+      multiformats: 9.6.2
+      uint8arrays: 3.0.0
+    dev: false
+
+  /ipfs-unixfs-importer/9.0.6:
+    resolution: {integrity: sha512-FgzODqg4pvToEMZ88mFkHcU0s25CljmnqX2VX7K/VQDckiZIxhIiUTQRqQg/C7Em4uCzVp8YCxKUvl++w6kvNg==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dependencies:
+      '@ipld/dag-pb': 2.1.15
+      '@multiformats/murmur3': 1.0.8
+      bl: 5.0.0
+      err-code: 3.0.1
+      hamt-sharding: 2.0.1
+      interface-blockstore: 1.0.2
+      ipfs-unixfs: 6.0.6
+      it-all: 1.0.6
+      it-batch: 1.0.9
+      it-first: 1.0.7
+      it-parallel-batch: 1.0.10
+      merge-options: 3.0.4
+      multiformats: 9.6.2
+      rabin-wasm: 0.1.5
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /ipfs-unixfs/6.0.6:
+    resolution: {integrity: sha512-gTkjYKXuHnqIf6EFfS+ESaYEl3I3aaQQ0UX8MhpNzreMLEuMnuqpoI/uLLllTZa31WRplKixabbpRTSmTYRNwA==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dependencies:
+      err-code: 3.0.1
+      protobufjs: 6.11.2
+    dev: false
+
+  /ipfs-utils/9.0.4:
+    resolution: {integrity: sha512-cfLKk004KLoEWJhBx4zg3mCro6mkiNhyGIlT7OZX9zxO1UqvLWpvW7cSZ1b1fbUIZ8qI7X2B7PeKlXC7jSfZ7g==}
+    dependencies:
+      any-signal: 3.0.0
+      buffer: 6.0.3
+      electron-fetch: 1.7.4
+      err-code: 3.0.1
+      is-electron: 2.2.1
+      iso-url: 1.2.1
+      it-glob: 1.0.2
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      nanoid: 3.2.0
+      native-fetch: 3.0.0_node-fetch@2.6.7
+      node-fetch: /@achingbrain/node-fetch/2.6.7
+      react-native-fetch-api: 2.0.0
+      stream-to-it: 0.2.4
+    dev: false
+
+  /ipns/0.16.0:
+    resolution: {integrity: sha512-fBYkRjN3/fc6IQujUF4WBEyOXegK715w+wx9IErV6H2B5JXsMnHOBceUKn3L90dj+wJfHs6T+hM/OZiTT6mQCw==}
+    dependencies:
+      cborg: 1.6.1
+      debug: 4.3.2
+      err-code: 3.0.1
+      interface-datastore: 6.0.3
+      libp2p-crypto: 0.21.2
+      long: 4.0.0
+      multiformats: 9.6.2
+      peer-id: 0.16.0
+      protobufjs: 6.11.2
+      timestamp-nano: 1.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /is-accessor-descriptor/0.1.6:
@@ -4622,6 +5733,11 @@ packages:
 
   /is-buffer/1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: false
+
+  /is-buffer/2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
     dev: false
 
   /is-callable/1.2.4:
@@ -4681,6 +5797,14 @@ packages:
       kind-of: 6.0.3
     dev: false
 
+  /is-domain-name/1.0.1:
+    resolution: {integrity: sha1-9uszsUpJdUHcpYM1E31EZuDCDaE=}
+    dev: false
+
+  /is-electron/2.2.1:
+    resolution: {integrity: sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw==}
+    dev: false
+
   /is-extendable/0.1.1:
     resolution: {integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=}
     engines: {node: '>=0.10.0'}
@@ -4727,6 +5851,31 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-ip/3.1.0:
+    resolution: {integrity: sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==}
+    engines: {node: '>=8'}
+    dependencies:
+      ip-regex: 4.3.0
+    dev: false
+
+  /is-ipfs/6.0.2:
+    resolution: {integrity: sha512-RinUnsggL4hlLoHlZcvs2+92OE46Uflg/YVU1m5fXhyDBS/zh3bq+i6Aw7IbzJZ9oZXJx26TgxpqCuCr+LH/DA==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dependencies:
+      iso-url: 1.2.1
+      mafmt: 10.0.0
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /is-loopback-addr/1.0.1:
+    resolution: {integrity: sha512-DhWU/kqY7X2F6KrrVTu7mHlbd2Pbo4D1YkAzasBMjQs6lJAoefxaA6m6CpSX0K6pjt9D0b9PNFI5zduy/vzOYw==}
+    dev: false
+
   /is-negative-zero/2.0.1:
     resolution: {integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==}
     engines: {node: '>= 0.4'}
@@ -4749,6 +5898,11 @@ packages:
   /is-number/7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: false
+
+  /is-plain-obj/2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
     dev: false
 
   /is-plain-object/2.0.4:
@@ -4830,6 +5984,25 @@ packages:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
     dev: false
 
+  /iso-constants/0.1.2:
+    resolution: {integrity: sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    dev: false
+
+  /iso-random-stream/2.0.2:
+    resolution: {integrity: sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      events: 3.3.0
+      readable-stream: 3.6.0
+    dev: false
+
+  /iso-url/1.2.1:
+    resolution: {integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==}
+    engines: {node: '>=12'}
+    dev: false
+
   /isobject/2.1.0:
     resolution: {integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=}
     engines: {node: '>=0.10.0'}
@@ -4840,6 +6013,10 @@ packages:
   /isobject/3.0.1:
     resolution: {integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /isstream/0.1.2:
+    resolution: {integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=}
     dev: false
 
   /istanbul-lib-coverage/3.2.0:
@@ -4898,6 +6075,175 @@ packages:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
+    dev: false
+
+  /it-all/1.0.6:
+    resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
+    dev: false
+
+  /it-batch/1.0.9:
+    resolution: {integrity: sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==}
+    dev: false
+
+  /it-buffer/0.1.3:
+    resolution: {integrity: sha512-9a2/9SYVwG7bcn3tpRDR4bXbtuMLXnDK48KVC+GXiQg97ZOOdWz2nIITBsOQ19b+gj01Rw8RNwtiLDLI8P8oiQ==}
+    dependencies:
+      bl: 5.0.0
+      buffer: 6.0.3
+    dev: false
+
+  /it-concat/2.0.0:
+    resolution: {integrity: sha512-jchrEB3fHlUENWkVJRmbFJ1A7gcjJDmwiolQsHhVC14DpUIbX8fgr3SOC7XNE5OoUUQNL6/RaMCPChkPemyQUw==}
+    dependencies:
+      bl: 5.0.0
+    dev: false
+
+  /it-drain/1.0.5:
+    resolution: {integrity: sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg==}
+    dev: false
+
+  /it-filter/1.0.3:
+    resolution: {integrity: sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w==}
+    dev: false
+
+  /it-first/1.0.7:
+    resolution: {integrity: sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==}
+    dev: false
+
+  /it-glob/1.0.2:
+    resolution: {integrity: sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==}
+    dependencies:
+      '@types/minimatch': 3.0.5
+      minimatch: 3.0.4
+    dev: false
+
+  /it-handshake/2.0.0:
+    resolution: {integrity: sha512-K4q+mz8aLlCK3vTjtgNdHC9c/JbuOATsfogarjMsLcBZC5vYfKbX3Gq3AWcCdjIsIrPqzTlhPKSxl64LJkrt2w==}
+    dependencies:
+      it-pushable: 1.4.2
+      it-reader: 3.0.0
+      p-defer: 3.0.0
+    dev: false
+
+  /it-last/1.0.6:
+    resolution: {integrity: sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==}
+    dev: false
+
+  /it-length-prefixed/5.0.3:
+    resolution: {integrity: sha512-b+jDHLcnOnPDQN79ronmzF5jeBjdJsy0ce2O6i6X4J5tnaO8Fd146ZA/tMbzaLlKnTpXa0eKtofpYhumXGENeg==}
+    dependencies:
+      bl: 5.0.0
+      buffer: 6.0.3
+      varint: 6.0.0
+    dev: false
+
+  /it-length/1.0.4:
+    resolution: {integrity: sha512-KN4jXzp77/GQ4fxUGMbsJx3ALUZ6SP3E79tzs2weGghtImDLFZzua/l3fOK0LN/hMH0M330HJRZWwYZfDNuCIA==}
+    dev: false
+
+  /it-map/1.0.6:
+    resolution: {integrity: sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==}
+    dev: false
+
+  /it-merge/1.0.4:
+    resolution: {integrity: sha512-DcL6GksTD2HQ7+5/q3JznXaLNfwjyG3/bObaF98da+oHfUiPmdo64oJlT9J8R8G5sJRU7thwaY5zxoAKCn7FJw==}
+    dependencies:
+      it-pushable: 1.4.2
+    dev: false
+
+  /it-pair/1.0.0:
+    resolution: {integrity: sha512-9raOiDu5OAuDOahtMtapKQDrQTxBfzlzrNcB6o7JARHkt+7Bb1dMkW/TpYdAjBJE77KH3e2zGzwpGUP9tXbLww==}
+    dependencies:
+      get-iterator: 1.0.2
+    dev: false
+
+  /it-parallel-batch/1.0.10:
+    resolution: {integrity: sha512-3+4gW15xdf/BOx9zij0QVnB1bDGSLOTABlaVm7ebHH1S9gDUgd5aLNb0WsFXPTfKe104iC6lxdzfbMGh1B07rg==}
+    dependencies:
+      it-batch: 1.0.9
+    dev: false
+
+  /it-parallel/2.0.1:
+    resolution: {integrity: sha512-VnHs9UJXSr8jmPnquS76qhLU+tE3WvLJqBUKMjAD2/Z1O5JsjpHMqq8yvVByyuwuFnh1OG9faJVGc5c9t+T6Kg==}
+    dependencies:
+      p-defer: 3.0.0
+    dev: false
+
+  /it-pb-rpc/0.2.0:
+    resolution: {integrity: sha512-Rojodsa6yxSTZDqVVF9HXKsISoHtlLNOL0P6b/7oCswiscbjCpt1IB78BxRDHpFL3tg8jFPMNDTP3v6ZjrMf9w==}
+    dependencies:
+      it-handshake: 2.0.0
+      it-length-prefixed: 5.0.3
+    dev: false
+
+  /it-peekable/1.0.3:
+    resolution: {integrity: sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==}
+    dev: false
+
+  /it-pipe/1.1.0:
+    resolution: {integrity: sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg==}
+    dev: false
+
+  /it-pushable/1.4.2:
+    resolution: {integrity: sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==}
+    dependencies:
+      fast-fifo: 1.1.0
+    dev: false
+
+  /it-reader/3.0.0:
+    resolution: {integrity: sha512-NxR40odATeaBmSefn6Xn43DplYvn2KtEKQzn4jrTRuPYXMky5M4e+KQ7aTJh0k0vkytLyeenGO1I1GXlGm4laQ==}
+    dependencies:
+      bl: 5.0.0
+    dev: false
+
+  /it-sort/1.0.1:
+    resolution: {integrity: sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==}
+    dependencies:
+      it-all: 1.0.6
+    dev: false
+
+  /it-take/1.0.2:
+    resolution: {integrity: sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw==}
+    dev: false
+
+  /it-tar/4.0.0:
+    resolution: {integrity: sha512-t7NJKNVs0p3aJT2cyycs8FkXkvLTKOVtcEuYEdZDrfxHGEIW8gHJt2zbDOILt5erywEPRRws2oz0FqH3LiDGtA==}
+    dependencies:
+      bl: 5.0.0
+      buffer: 6.0.3
+      iso-constants: 0.1.2
+      it-concat: 2.0.0
+      it-reader: 3.0.0
+      p-defer: 3.0.0
+    dev: false
+
+  /it-to-buffer/2.0.2:
+    resolution: {integrity: sha512-Frbv1sphcNFvD807Qw5fXpK4L7iuqShYSI7k30PfpJiy5IxdqMyaulWpLyl1hIJVVpkG+1UrJafFCnatzmZf5g==}
+    dependencies:
+      uint8arrays: 3.0.0
+    dev: false
+
+  /it-to-stream/1.0.0:
+    resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
+    dependencies:
+      buffer: 6.0.3
+      fast-fifo: 1.1.0
+      get-iterator: 1.0.2
+      p-defer: 3.0.0
+      p-fifo: 1.0.0
+      readable-stream: 3.6.0
+    dev: false
+
+  /it-ws/4.0.0:
+    resolution: {integrity: sha512-XmTzpMkevc6rUboy73r0CCNhciMmL/Yxir9O6FujRwdrjysztqLBQ1Xkr4CpY2m7BVSCObKotaCWJeZ29lOXRA==}
+    dependencies:
+      buffer: 6.0.3
+      event-iterator: 2.0.0
+      iso-url: 1.2.1
+      ws: 7.4.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /iterare/1.2.1:
@@ -5478,6 +6824,14 @@ packages:
       argparse: 2.0.1
     dev: false
 
+  /jsbn/0.1.1:
+    resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
+    dev: false
+
+  /jsbn/1.1.0:
+    resolution: {integrity: sha1-sBMHyym2GKHtJux56RH4A8TaAEA=}
+    dev: false
+
   /jsdom/16.7.0:
     resolution: {integrity: sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==}
     engines: {node: '>=10'}
@@ -5542,8 +6896,16 @@ packages:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: false
 
+  /json-schema/0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
+
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=}
+    dev: false
+
+  /json-stringify-safe/5.0.1:
+    resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
     dev: false
 
   /json5/1.0.1:
@@ -5573,12 +6935,40 @@ packages:
       graceful-fs: 4.2.8
     dev: false
 
+  /jsprim/1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+    dev: false
+
   /jsx-ast-utils/2.4.1:
     resolution: {integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.4
       object.assign: 4.1.2
+    dev: false
+
+  /just-debounce-it/1.5.0:
+    resolution: {integrity: sha512-itSWJS5d2DTSCizVJ2Z0Djx/dGmUGfZe7WNfUfVP23+htGcIcPHbEjL4eB8ljojTs/+oYwLexImRRCP0A2WXjA==}
+    dev: false
+
+  /just-safe-get/2.1.2:
+    resolution: {integrity: sha512-DPWEh00QFgJNyfULPwgc9rTvdiPYVyt69hcgjWbN3lzKMmISW43Hwc+nlRAIo+su6PLVqUOMEUJNYR1xFog7xQ==}
+    dev: false
+
+  /just-safe-set/2.2.3:
+    resolution: {integrity: sha512-6zAkfGKRjB766zXv/UVSGOFKSAqakhwLQDyIR9bmIhJ/e6jS3Ci1VxYTqaiooYZZUw3VLg0sZva8PE6JX/iu2w==}
+    dev: false
+
+  /k-bucket/5.1.0:
+    resolution: {integrity: sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==}
+    dependencies:
+      randombytes: 2.1.0
     dev: false
 
   /kind-of/3.2.2:
@@ -5610,6 +7000,87 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /level-codec/10.0.0:
+    resolution: {integrity: sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==}
+    engines: {node: '>=10'}
+    dependencies:
+      buffer: 6.0.3
+    dev: false
+
+  /level-concat-iterator/3.1.0:
+    resolution: {integrity: sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      catering: 2.1.1
+    dev: false
+
+  /level-errors/3.0.1:
+    resolution: {integrity: sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /level-iterator-stream/5.0.0:
+    resolution: {integrity: sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==}
+    engines: {node: '>=10'}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: false
+
+  /level-js/6.1.0:
+    resolution: {integrity: sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==}
+    dependencies:
+      abstract-leveldown: 7.2.0
+      buffer: 6.0.3
+      inherits: 2.0.4
+      ltgt: 2.2.1
+      run-parallel-limit: 1.1.0
+    dev: false
+
+  /level-packager/6.0.1:
+    resolution: {integrity: sha512-8Ezr0XM6hmAwqX9uu8IGzGNkWz/9doyPA8Oo9/D7qcMI6meJC+XhIbNYHukJhIn8OGdlzQs/JPcL9B8lA2F6EQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      encoding-down: 7.1.0
+      levelup: 5.1.1
+    dev: false
+
+  /level-supports/2.1.0:
+    resolution: {integrity: sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /level/7.0.1:
+    resolution: {integrity: sha512-w3E64+ALx2eZf8RV5JL4kIcE0BFAvQscRYd1yU4YVqZN9RGTQxXSvH202xvK15yZwFFxRXe60f13LJjcJ//I4Q==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      level-js: 6.1.0
+      level-packager: 6.0.1
+      leveldown: 6.1.0
+    dev: false
+
+  /leveldown/6.1.0:
+    resolution: {integrity: sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==}
+    engines: {node: '>=10.12.0'}
+    requiresBuild: true
+    dependencies:
+      abstract-leveldown: 7.2.0
+      napi-macros: 2.0.0
+      node-gyp-build: 4.3.0
+    dev: false
+
+  /levelup/5.1.1:
+    resolution: {integrity: sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==}
+    engines: {node: '>=10'}
+    dependencies:
+      catering: 2.1.1
+      deferred-leveldown: 7.0.0
+      level-errors: 3.0.1
+      level-iterator-stream: 5.0.0
+      level-supports: 2.1.0
+      queue-microtask: 1.2.3
+    dev: false
+
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5629,6 +7100,340 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: false
+
+  /libp2p-bootstrap/0.14.0:
+    resolution: {integrity: sha512-j3slZo5nOdA8wVlav8dRZeAXutZ7psz/f10DLoIEX/EFif7uU5oZfIYvjbVGo3ZDl+VQLo2tR0m1lV0westQ3g==}
+    engines: {node: '>=15.0.0'}
+    dependencies:
+      debug: 4.3.2
+      mafmt: 10.0.0
+      multiaddr: 10.0.1
+      peer-id: 0.16.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-crypto/0.21.2:
+    resolution: {integrity: sha512-EXFrhSpiHtJ+/L8xXDvQNK5VjUMG51u878jzZcaT5XhuN/zFg6PWJFnl/qB2Y2j7eMWnvCRP7Kp+ua2H36cG4g==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@noble/ed25519': 1.5.1
+      '@noble/secp256k1': 1.5.1
+      err-code: 3.0.1
+      iso-random-stream: 2.0.2
+      multiformats: 9.6.2
+      node-forge: 1.2.1
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+    dev: false
+
+  /libp2p-delegated-content-routing/0.11.2:
+    resolution: {integrity: sha512-O7bqOPGlvePsP4ld6AU4uDuHjTQ9lVfsTFkYqhwPVUw1rxR0UiGiU5eyq6ADlgrY3lHtz3Sc3yNVFN1FNDn1iA==}
+    dependencies:
+      debug: 4.3.2
+      it-drain: 1.0.5
+      multiaddr: 10.0.1
+      p-defer: 3.0.0
+      p-queue: 6.6.2
+      peer-id: 0.16.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-delegated-peer-routing/0.11.1:
+    resolution: {integrity: sha512-NwdRS0a6plfzVcdSqHV4hQnv872zjt7dUtsfRXmPZkXoaPjWck3Y0EDFxDYHlCMPH9w7PvrgttBlO1EwWqFGFw==}
+    dependencies:
+      debug: 4.3.2
+      multiformats: 9.6.2
+      p-defer: 3.0.0
+      p-queue: 6.6.2
+      peer-id: 0.16.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /libp2p-floodsub/0.28.0:
+    resolution: {integrity: sha512-I9qR7j79HbRgmIq/UkLauzAIcPbM/uJCk2bJNKobgyJMs7nt8KSwQS2I5JEf4Jc9j9toCh5MKQ6/ynyLoSjIig==}
+    dependencies:
+      debug: 4.3.2
+      libp2p-interfaces: 2.0.9
+      time-cache: 0.3.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-gossipsub/0.12.3:
+    resolution: {integrity: sha512-Oyjt1jGoQm4t/L6t+NUToQPP5kwTailzFrzTnNTVSfKi8WCUty2ua2ttnq3ZEG4rUxlGDgqmOQoI6bfmjdvRNw==}
+    dependencies:
+      '@types/debug': 4.1.7
+      debug: 4.3.2
+      denque: 1.5.1
+      err-code: 3.0.1
+      it-pipe: 1.1.0
+      libp2p-interfaces: 2.0.9
+      peer-id: 0.16.0
+      protobufjs: 6.11.2
+      time-cache: 0.3.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-interfaces/2.0.9:
+    resolution: {integrity: sha512-KYPYBy7dprcc9cy9PdoJyljs//Gb7A1448jNl/egfxIETKZl4uvYK66l4lzLtKB3AblIxATB8BFWEY/ph86QIA==}
+    dependencies:
+      abortable-iterator: 3.0.2
+      debug: 4.3.2
+      err-code: 3.0.1
+      it-length-prefixed: 5.0.3
+      it-pipe: 1.1.0
+      it-pushable: 1.4.2
+      libp2p-crypto: 0.21.2
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      p-queue: 6.6.2
+      peer-id: 0.16.0
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-kad-dht/0.27.6:
+    resolution: {integrity: sha512-mynm9yQyz3UnuGCCj54iT6irHu7Dt0Yv1vvJfdtXolU9U7uNdoNxVxBftb8NC3O9aj9Almt3QYmhCR8lOuww8Q==}
+    engines: {node: '>=15.0.0'}
+    dependencies:
+      any-signal: 2.1.2
+      datastore-core: 6.0.7
+      debug: 4.3.2
+      err-code: 3.0.1
+      hashlru: 2.3.0
+      interface-datastore: 6.0.3
+      it-all: 1.0.6
+      it-drain: 1.0.5
+      it-first: 1.0.7
+      it-length: 1.0.4
+      it-length-prefixed: 5.0.3
+      it-map: 1.0.6
+      it-merge: 1.0.4
+      it-parallel: 2.0.1
+      it-pipe: 1.1.0
+      it-take: 1.0.2
+      k-bucket: 5.1.0
+      libp2p-crypto: 0.21.2
+      libp2p-interfaces: 2.0.9
+      libp2p-record: 0.10.6
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      native-abort-controller: 1.0.4
+      p-defer: 3.0.0
+      p-map: 4.0.0
+      p-queue: 6.6.2
+      peer-id: 0.16.0
+      private-ip: 2.3.3
+      protobufjs: 6.11.2
+      streaming-iterables: 6.0.0
+      timeout-abort-controller: 2.0.0
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - abort-controller
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-mdns/0.18.0:
+    resolution: {integrity: sha512-IBCKRuNc5USlli9QF/gOq2loCssE4ZKkVRhUNuAVBRXJ8ueqFEquc5R5C1sWy7AOgbycTgeNcxzSa1kuNb6nbg==}
+    dependencies:
+      debug: 4.3.2
+      multiaddr: 10.0.1
+      multicast-dns: 7.2.4
+      peer-id: 0.16.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-mplex/0.10.7:
+    resolution: {integrity: sha512-21VV0DZWuOsHgitWy1GZD1M/kki3a/hVoAJ5QC48p01JNSK5W8gxRiZtq7cCGJ/xNpbQxvMlMtS5eq8CFRlysg==}
+    dependencies:
+      abortable-iterator: 3.0.2
+      bl: 5.0.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      it-pipe: 1.1.0
+      it-pushable: 1.4.2
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /libp2p-record/0.10.6:
+    resolution: {integrity: sha512-CbdO2P9DQn/DKll6R/J4nIw6Qt8xbUTfxYgJjpP9oz3izHKkpGQo0mPTe0NyuFTGIQ4OprrxqWqG5v8ZCGBqqw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      err-code: 3.0.1
+      multiformats: 9.6.2
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+    dev: false
+
+  /libp2p-tcp/0.17.2:
+    resolution: {integrity: sha512-SAdgDB4Rm0olPbyvanKP5JBaiRwbIOo0Nt++WYe1U2B6akg2uatsDOtulfpnc1gsL1B5vamnOpOzKaDj4kkt8g==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      abortable-iterator: 3.0.2
+      class-is: 1.1.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      libp2p-utils: 0.4.1
+      mafmt: 10.0.0
+      multiaddr: 10.0.1
+      stream-to-it: 0.2.4
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-utils/0.4.1:
+    resolution: {integrity: sha512-kq/US2unamiyY+YwP47dO1uqpAdcbdYI2Fzi9JIEhjfPBaD1MR/uyQ/YP7ABthl3EaxAjIQYd1TVp85d6QKAtQ==}
+    dependencies:
+      abortable-iterator: 3.0.2
+      debug: 4.3.2
+      err-code: 3.0.1
+      ip-address: 8.1.0
+      is-loopback-addr: 1.0.1
+      multiaddr: 10.0.1
+      private-ip: 2.3.3
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /libp2p-webrtc-peer/10.0.1:
+    resolution: {integrity: sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==}
+    dependencies:
+      debug: 4.3.2
+      err-code: 2.0.3
+      get-browser-rtc: 1.1.0
+      queue-microtask: 1.2.3
+      randombytes: 2.1.0
+      readable-stream: 3.6.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /libp2p-webrtc-star/0.25.0:
+    resolution: {integrity: sha512-SyXjHDrm+qlKQE5HIddrUCSwkxCIJ30PAH4ZVNNADkC0F5IVQY9EoVJ+/rrzZuDDqccnS15TgxW13vmybX96bQ==}
+    dependencies:
+      abortable-iterator: 3.0.2
+      class-is: 1.1.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      ipfs-utils: 9.0.4
+      it-pipe: 1.1.0
+      libp2p-utils: 0.4.1
+      libp2p-webrtc-peer: 10.0.1
+      mafmt: 10.0.0
+      multiaddr: 10.0.1
+      p-defer: 3.0.0
+      peer-id: 0.16.0
+      socket.io-client: 4.4.1
+      stream-to-it: 0.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /libp2p-websockets/0.16.2:
+    resolution: {integrity: sha512-QGfo8jX1Ks16yi8C67CCyMW7k9cfCYiQ0lzKVJBud0fV3ymbMO2L8gzU6iXUUZTHILo8ka26zKhwQ4lmUMI+nA==}
+    dependencies:
+      abortable-iterator: 3.0.2
+      class-is: 1.1.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      ipfs-utils: 9.0.4
+      it-ws: 4.0.0
+      libp2p-utils: 0.4.1
+      mafmt: 10.0.0
+      multiaddr: 10.0.1
+      multiaddr-to-uri: 8.0.0
+      p-defer: 3.0.0
+      p-timeout: 4.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /libp2p/0.35.8:
+    resolution: {integrity: sha512-1Vkm7+v6bXwjlBeuiKNLtRxPIDBWFe+dt17tye0XF1BeMOY8UFUN0QeEAYrOBs6Ses+sO4oZ6OwPtcNr3zrkMw==}
+    engines: {node: '>=15.0.0'}
+    dependencies:
+      '@vascosantos/moving-average': 1.1.0
+      abort-controller: 3.0.0
+      abortable-iterator: 3.0.2
+      aggregate-error: 3.1.0
+      any-signal: 2.1.2
+      bignumber.js: 9.0.2
+      class-is: 1.1.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      es6-promisify: 7.0.0
+      events: 3.3.0
+      hashlru: 2.3.0
+      interface-datastore: 6.0.3
+      it-all: 1.0.6
+      it-buffer: 0.1.3
+      it-drain: 1.0.5
+      it-filter: 1.0.3
+      it-first: 1.0.7
+      it-handshake: 2.0.0
+      it-length-prefixed: 5.0.3
+      it-map: 1.0.6
+      it-merge: 1.0.4
+      it-pipe: 1.1.0
+      it-take: 1.0.2
+      libp2p-crypto: 0.21.2
+      libp2p-interfaces: 2.0.9
+      libp2p-utils: 0.4.1
+      mafmt: 10.0.0
+      merge-options: 3.0.4
+      multiaddr: 10.0.1
+      multiformats: 9.6.2
+      multistream-select: 2.0.1
+      mutable-proxy: 1.0.0
+      nat-api: 0.3.1
+      node-forge: 0.10.0
+      p-any: 3.0.0
+      p-fifo: 1.0.0
+      p-retry: 4.6.1
+      p-settle: 4.1.1
+      peer-id: 0.16.0
+      private-ip: 2.3.3
+      protobufjs: 6.11.2
+      retimer: 3.0.0
+      sanitize-filename: 1.6.3
+      set-delayed-interval: 1.0.0
+      streaming-iterables: 6.0.0
+      timeout-abort-controller: 2.0.0
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+      wherearewe: 1.0.0
+      xsalsa20: 1.2.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
     dev: false
 
   /libphonenumber-js/1.9.42:
@@ -5671,6 +7476,10 @@ packages:
     resolution: {integrity: sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=}
     dev: false
 
+  /lodash.throttle/4.1.1:
+    resolution: {integrity: sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=}
+    dev: false
+
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=}
     dev: false
@@ -5687,6 +7496,10 @@ packages:
       is-unicode-supported: 0.1.0
     dev: false
 
+  /long/4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+    dev: false
+
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -5701,9 +7514,22 @@ packages:
       yallist: 4.0.0
     dev: false
 
+  /ltgt/2.2.1:
+    resolution: {integrity: sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=}
+    dev: false
+
   /macos-release/2.5.0:
     resolution: {integrity: sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==}
     engines: {node: '>=6'}
+    dev: false
+
+  /mafmt/10.0.0:
+    resolution: {integrity: sha512-K1bziJOXcnepfztu+2Xy9FLKVLaFMDuspmiyJIYRxnO0WOxFSV7XKSdMxMrVZxcvg1+YjlTIvSGTImUHU2k4Aw==}
+    dependencies:
+      multiaddr: 10.0.1
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
     dev: false
 
   /magic-string/0.25.7:
@@ -5755,6 +7581,13 @@ packages:
 
   /merge-descriptors/1.0.1:
     resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
+    dev: false
+
+  /merge-options/3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      is-plain-obj: 2.1.0
     dev: false
 
   /merge-stream/2.0.0:
@@ -5890,6 +7723,15 @@ packages:
     hasBin: true
     dev: false
 
+  /mortice/2.0.1:
+    resolution: {integrity: sha512-9gsXmjq+5LZmXDIoyC/crf2i/7CUwDGSBEwSEsr1i/WfKmJ6DVt38B5kg6BE/WF/1/yfGJYiB1Wyiu423iI3nQ==}
+    dependencies:
+      nanoid: 3.2.0
+      observable-webworkers: 1.0.0
+      p-queue: 6.6.2
+      promise-timeout: 1.3.0
+    dev: false
+
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
     dev: false
@@ -5916,6 +7758,68 @@ packages:
       xtend: 4.0.2
     dev: false
 
+  /multiaddr-to-uri/8.0.0:
+    resolution: {integrity: sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==}
+    dependencies:
+      multiaddr: 10.0.1
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /multiaddr/10.0.1:
+    resolution: {integrity: sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==}
+    dependencies:
+      dns-over-http-resolver: 1.2.3
+      err-code: 3.0.1
+      is-ip: 3.1.0
+      multiformats: 9.6.2
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+    dev: false
+
+  /multicast-dns/7.2.4:
+    resolution: {integrity: sha512-XkCYOU+rr2Ft3LI6w4ye51M3VK31qJXFIxu0XLw169PtKG0Zx47OrXeVW/GCYOfpC9s1yyyf1S+L8/4LY0J9Zw==}
+    hasBin: true
+    dependencies:
+      dns-packet: 5.3.1
+      thunky: 1.1.0
+    dev: false
+
+  /multiformats/9.6.2:
+    resolution: {integrity: sha512-1dKng7RkBelbEZQQD2zvdzYKgUmtggpWl+GXQBYhnEGGkV6VIYfWgV3VSeyhcUFFEelI5q4D0etCJZ7fbuiamQ==}
+    dev: false
+
+  /multistream-select/2.0.1:
+    resolution: {integrity: sha512-ziVNT/vux0uUElP4OKNMVr0afU/X6PciAmT2UJNolhzhSLXIwFAaYfmLajD8NoZ+DsBQ1bp0zZ2nMVPF+FhClA==}
+    dependencies:
+      bl: 5.0.0
+      debug: 4.3.2
+      err-code: 3.0.1
+      it-first: 1.0.7
+      it-handshake: 2.0.0
+      it-length-prefixed: 5.0.3
+      it-pipe: 1.1.0
+      it-reader: 3.0.0
+      p-defer: 3.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /murmurhash3js-revisited/3.0.0:
+    resolution: {integrity: sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
+  /mutable-proxy/1.0.0:
+    resolution: {integrity: sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A==}
+    engines: {node: '>=6.X.X', npm: '>=3.X.X'}
+    dev: false
+
   /mute-stream/0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
     dev: false
@@ -5926,6 +7830,12 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+    dev: false
+
+  /nanoid/3.2.0:
+    resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
     dev: false
 
   /nanomatch/1.2.13:
@@ -5949,6 +7859,52 @@ packages:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
     dev: false
 
+  /napi-macros/2.0.0:
+    resolution: {integrity: sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==}
+    dev: false
+
+  /nat-api/0.3.1:
+    resolution: {integrity: sha512-5cyLugEkXnKSKSvVjKjxxPMLDnkwY3boZLbATWwiGJ4T/3UvIpiQmzb2RqtxxEFcVo/7PwsHPGN0MosopONO8Q==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      async: 3.2.3
+      debug: 4.3.2
+      default-gateway: 6.0.3
+      request: 2.88.2
+      unordered-array-remove: 1.0.2
+      xml2js: 0.1.14
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /native-abort-controller/1.0.4:
+    resolution: {integrity: sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==}
+    peerDependencies:
+      abort-controller: '*'
+    dev: false
+
+  /native-abort-controller/1.0.4_abort-controller@3.0.0:
+    resolution: {integrity: sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==}
+    peerDependencies:
+      abort-controller: '*'
+    dependencies:
+      abort-controller: 3.0.0
+    dev: false
+
+  /native-fetch/3.0.0:
+    resolution: {integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==}
+    peerDependencies:
+      node-fetch: '*'
+    dev: false
+
+  /native-fetch/3.0.0_node-fetch@2.6.7:
+    resolution: {integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==}
+    peerDependencies:
+      node-fetch: '*'
+    dependencies:
+      node-fetch: /@achingbrain/node-fetch/2.6.7
+    dev: false
+
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: false
@@ -5960,6 +7916,11 @@ packages:
 
   /neo-async/2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: false
+
+  /netmask/2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
     dev: false
 
   /nice-try/1.0.5:
@@ -5990,11 +7951,15 @@ packages:
     engines: {node: '>= 6.0.0'}
     dev: false
 
+  /node-forge/1.2.1:
+    resolution: {integrity: sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==}
+    engines: {node: '>= 6.13.0'}
+    dev: false
+
   /node-gyp-build/4.3.0:
     resolution: {integrity: sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==}
     hasBin: true
     dev: false
-    optional: true
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
@@ -6051,6 +8016,10 @@ packages:
 
   /nwsapi/2.2.0:
     resolution: {integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==}
+    dev: false
+
+  /oauth-sign/0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
     dev: false
 
   /object-assign/4.1.1:
@@ -6132,6 +8101,10 @@ packages:
       es-abstract: 1.19.1
     dev: false
 
+  /observable-webworkers/1.0.0:
+    resolution: {integrity: sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ==}
+    dev: false
+
   /on-finished/2.3.0:
     resolution: {integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=}
     engines: {node: '>= 0.8'}
@@ -6208,6 +8181,31 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /p-any/3.0.0:
+    resolution: {integrity: sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-cancelable: 2.1.1
+      p-some: 5.0.0
+    dev: false
+
+  /p-cancelable/2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /p-defer/3.0.0:
+    resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /p-fifo/1.0.0:
+    resolution: {integrity: sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==}
+    dependencies:
+      fast-fifo: 1.1.0
+      p-defer: 3.0.0
+    dev: false
+
   /p-finally/1.0.0:
     resolution: {integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=}
     engines: {node: '>=4'}
@@ -6234,9 +8232,69 @@ packages:
       p-limit: 2.3.0
     dev: false
 
+  /p-map/4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      aggregate-error: 3.1.0
+    dev: false
+
+  /p-queue/6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+    dev: false
+
+  /p-reflect/2.1.0:
+    resolution: {integrity: sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /p-retry/4.6.1:
+    resolution: {integrity: sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/retry': 0.12.1
+      retry: 0.13.1
+    dev: false
+
+  /p-settle/4.1.1:
+    resolution: {integrity: sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      p-limit: 2.3.0
+      p-reflect: 2.1.0
+    dev: false
+
+  /p-some/5.0.0:
+    resolution: {integrity: sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==}
+    engines: {node: '>=10'}
+    dependencies:
+      aggregate-error: 3.1.0
+      p-cancelable: 2.1.1
+    dev: false
+
+  /p-timeout/3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-finally: 1.0.0
+    dev: false
+
+  /p-timeout/4.1.0:
+    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: false
+
+  /pako/1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
     dev: false
 
   /parent-module/1.0.1:
@@ -6249,6 +8307,10 @@ packages:
   /parent-require/1.0.0:
     resolution: {integrity: sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc=}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /parse-duration/1.0.2:
+    resolution: {integrity: sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg==}
     dev: false
 
   /parse-json/5.2.0:
@@ -6273,6 +8335,14 @@ packages:
 
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
+  /parseqs/0.0.6:
+    resolution: {integrity: sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==}
+    dev: false
+
+  /parseuri/0.0.6:
+    resolution: {integrity: sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==}
     dev: false
 
   /parseurl/1.3.3:
@@ -6320,6 +8390,21 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+    dev: false
+
+  /peer-id/0.16.0:
+    resolution: {integrity: sha512-EmL7FurFUduU9m1PS9cfJ5TAuCvxKQ7DKpfx3Yj6IKWyBRtosriFuOag/l3ni/dtPgPLwiA4R9IvpL7hsDLJuQ==}
+    engines: {node: '>=15.0.0'}
+    dependencies:
+      class-is: 1.1.0
+      libp2p-crypto: 0.21.2
+      multiformats: 9.6.2
+      protobufjs: 6.11.2
+      uint8arrays: 3.0.0
+    dev: false
+
+  /performance-now/2.1.0:
+    resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
     dev: false
 
   /picocolors/1.0.0:
@@ -6418,6 +8503,15 @@ packages:
       react-is: 17.0.2
     dev: false
 
+  /private-ip/2.3.3:
+    resolution: {integrity: sha512-5zyFfekIVUOTVbL92hc8LJOtE/gyGHeREHkJ2yTyByP8Q2YZVoBqLg3EfYLeF0oVvGqtaEX2t2Qovja0/gStXw==}
+    dependencies:
+      ip-regex: 4.3.0
+      ipaddr.js: 2.0.1
+      is-ip: 3.1.0
+      netmask: 2.0.2
+    dev: false
+
   /process-nextick-args/2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: false
@@ -6425,6 +8519,10 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: false
+
+  /promise-timeout/1.3.0:
+    resolution: {integrity: sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==}
     dev: false
 
   /prompts/2.4.2:
@@ -6441,6 +8539,34 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: false
+
+  /proper-lockfile/4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+    dependencies:
+      graceful-fs: 4.2.8
+      retry: 0.12.0
+      signal-exit: 3.0.5
+    dev: false
+
+  /protobufjs/6.11.2:
+    resolution: {integrity: sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.1
+      '@types/node': 16.11.6
+      long: 4.0.0
     dev: false
 
   /proxy-addr/2.0.7:
@@ -6474,6 +8600,11 @@ packages:
       side-channel: 1.0.4
     dev: false
 
+  /qs/6.5.3:
+    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /qs/6.7.0:
     resolution: {integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==}
     engines: {node: '>=0.6'}
@@ -6487,6 +8618,20 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: false
+
+  /rabin-wasm/0.1.5:
+    resolution: {integrity: sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==}
+    hasBin: true
+    dependencies:
+      '@assemblyscript/loader': 0.9.4
+      bl: 5.0.0
+      debug: 4.3.2
+      minimist: 1.2.5
+      node-fetch: 2.6.6
+      readable-stream: 3.6.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /randombytes/2.1.0:
@@ -6528,6 +8673,12 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: false
 
+  /react-native-fetch-api/2.0.0:
+    resolution: {integrity: sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==}
+    dependencies:
+      p-defer: 3.0.0
+    dev: false
+
   /readable-stream/1.1.14:
     resolution: {integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=}
     dependencies:
@@ -6563,6 +8714,12 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.0
+    dev: false
+
+  /receptacle/1.3.2:
+    resolution: {integrity: sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==}
+    dependencies:
+      ms: 2.1.2
     dev: false
 
   /rechoir/0.6.2:
@@ -6609,6 +8766,33 @@ packages:
   /repeat-string/1.6.1:
     resolution: {integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=}
     engines: {node: '>=0.10'}
+    dev: false
+
+  /request/2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.11.0
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.33
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.3
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
     dev: false
 
   /require-directory/2.1.1:
@@ -6675,6 +8859,20 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
+  /retimer/3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+    dev: false
+
+  /retry/0.12.0:
+    resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
+    engines: {node: '>= 4'}
+    dev: false
+
+  /retry/0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: false
+
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -6695,6 +8893,12 @@ packages:
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
+    dev: false
+
+  /run-parallel-limit/1.1.0:
+    resolution: {integrity: sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==}
+    dependencies:
+      queue-microtask: 1.2.3
     dev: false
 
   /run-parallel/1.2.0:
@@ -6749,6 +8953,12 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.5
       walker: 1.0.8
+    dev: false
+
+  /sanitize-filename/1.6.3:
+    resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
     dev: false
 
   /sax/1.2.4:
@@ -6843,6 +9053,10 @@ packages:
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
+    dev: false
+
+  /set-delayed-interval/1.0.0:
+    resolution: {integrity: sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw==}
     dev: false
 
   /set-value/2.0.1:
@@ -6973,6 +9187,32 @@ packages:
       use: 3.1.1
     dev: false
 
+  /socket.io-client/4.4.1:
+    resolution: {integrity: sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.0.0
+      backo2: 1.0.2
+      debug: 4.3.2
+      engine.io-client: 6.1.1
+      parseuri: 0.0.6
+      socket.io-parser: 4.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /socket.io-parser/4.1.1:
+    resolution: {integrity: sha512-USQVLSkDWE5nbcY760ExdKaJxCE65kcsG/8k5FDGZVVxpD1pA7hABYXYkCUvxUuYYh/+uQw0N/fvBzfT8o07KA==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@socket.io/component-emitter': 3.0.0
+      debug: 4.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /sodium-native/3.3.0:
     resolution: {integrity: sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==}
     requiresBuild: true
@@ -6980,6 +9220,13 @@ packages:
       node-gyp-build: 4.3.0
     dev: false
     optional: true
+
+  /sort-keys/4.2.0:
+    resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-plain-obj: 2.1.0
+    dev: false
 
   /source-map-resolve/0.5.3:
     resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
@@ -7021,6 +9268,10 @@ packages:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     dev: false
 
+  /sparse-array/1.3.2:
+    resolution: {integrity: sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==}
+    dev: false
+
   /split-string/3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
@@ -7030,6 +9281,26 @@ packages:
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
+    dev: false
+
+  /sprintf-js/1.1.2:
+    resolution: {integrity: sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==}
+    dev: false
+
+  /sshpk/1.17.0:
+    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
     dev: false
 
   /stack-utils/2.0.5:
@@ -7050,6 +9321,17 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /stream-to-it/0.2.4:
+    resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
+    dependencies:
+      get-iterator: 1.0.2
+    dev: false
+
+  /streaming-iterables/6.0.0:
+    resolution: {integrity: sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q==}
+    engines: {node: '>=10'}
     dev: false
 
   /streamsearch/0.1.2:
@@ -7385,6 +9667,29 @@ packages:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
     dev: false
 
+  /thunky/1.1.0:
+    resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+    dev: false
+
+  /time-cache/0.3.0:
+    resolution: {integrity: sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=}
+    dependencies:
+      lodash.throttle: 4.1.1
+    dev: false
+
+  /timeout-abort-controller/2.0.0:
+    resolution: {integrity: sha512-2FAPXfzTPYEgw27bQGTHc0SzrbmnU2eso4qo172zMLZzaGqeu09PFa5B2FCUHM1tflgRqPgn5KQgp6+Vex4uNA==}
+    dependencies:
+      abort-controller: 3.0.0
+      native-abort-controller: 1.0.4_abort-controller@3.0.0
+      retimer: 3.0.0
+    dev: false
+
+  /timestamp-nano/1.0.0:
+    resolution: {integrity: sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA==}
+    engines: {node: '>= 4.5.0'}
+    dev: false
+
   /tmp/0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -7438,6 +9743,14 @@ packages:
     engines: {node: '>=0.6'}
     dev: false
 
+  /tough-cookie/2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+    dependencies:
+      psl: 1.8.0
+      punycode: 2.1.1
+    dev: false
+
   /tough-cookie/4.0.0:
     resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
     engines: {node: '>=6'}
@@ -7461,6 +9774,12 @@ packages:
   /tree-kill/1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+    dev: false
+
+  /truncate-utf8-bytes/1.0.2:
+    resolution: {integrity: sha1-QFkjkJWS1W94pYGENLC3hInKXys=}
+    dependencies:
+      utf8-byte-length: 1.0.4
     dev: false
 
   /ts-jest/27.0.7_ec3222e78695a6b5e6d9aa95aceec9d7:
@@ -7724,6 +10043,12 @@ packages:
     hasBin: true
     dev: false
 
+  /uint8arrays/3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+    dependencies:
+      multiformats: 9.6.2
+    dev: false
+
   /unbox-primitive/1.0.1:
     resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==}
     dependencies:
@@ -7751,6 +10076,10 @@ packages:
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: false
+
+  /unordered-array-remove/1.0.2:
+    resolution: {integrity: sha1-xUbo+I4xegzyZEyX7LV9umbSUO8=}
     dev: false
 
   /unpipe/1.0.0:
@@ -7782,6 +10111,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /utf8-byte-length/1.0.4:
+    resolution: {integrity: sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=}
+    dev: false
+
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
     dev: false
@@ -7789,6 +10122,12 @@ packages:
   /utils-merge/1.0.1:
     resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /uuid/3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
     dev: false
 
   /uuid/8.3.2:
@@ -7814,9 +10153,33 @@ packages:
     engines: {node: '>= 0.10'}
     dev: false
 
+  /varint-decoder/1.0.0:
+    resolution: {integrity: sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==}
+    engines: {node: '>=4.0.0', npm: '>=3.0.0'}
+    dependencies:
+      varint: 5.0.2
+    dev: false
+
+  /varint/5.0.2:
+    resolution: {integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==}
+    dev: false
+
+  /varint/6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+    dev: false
+
   /vary/1.1.2:
     resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
     engines: {node: '>= 0.8'}
+    dev: false
+
+  /verror/1.10.0:
+    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
+    engines: {'0': node >=0.6.0}
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
     dev: false
 
   /w3c-hr-time/1.0.2:
@@ -7942,6 +10305,12 @@ packages:
       webidl-conversions: 6.1.0
     dev: false
 
+  /wherearewe/1.0.0:
+    resolution: {integrity: sha512-oQnRsAfMCqNAC7U4JrBdmFXAhBRLOkPGOfU5+nw9fs2D3g8O6EV7hn7BhpXtt0yno4pxFiRD55rMyt0fsLMqlw==}
+    dependencies:
+      is-electron: 2.2.1
+    dev: false
+
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
@@ -8020,6 +10389,19 @@ packages:
         optional: true
     dev: false
 
+  /ws/8.2.3:
+    resolution: {integrity: sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /x25519-key-pair/3.1.0:
     resolution: {integrity: sha512-i+kbYsZfmbtqy7PmG936h1rtYLm5vMTObOcQ3jVjFdgmdCxCyqRHHRTGg23014QGZ/b5vXfh4+zx3xdAbTOzXQ==}
     dependencies:
@@ -8032,6 +10414,12 @@ packages:
 
   /xml-name-validator/3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+    dev: false
+
+  /xml2js/0.1.14:
+    resolution: {integrity: sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=}
+    dependencies:
+      sax: 1.2.4
     dev: false
 
   /xml2js/0.4.23:
@@ -8049,6 +10437,15 @@ packages:
 
   /xmlchars/2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    dev: false
+
+  /xmlhttprequest-ssl/2.0.0:
+    resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /xsalsa20/1.2.0:
+    resolution: {integrity: sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w==}
     dev: false
 
   /xtend/4.0.2:
@@ -8109,6 +10506,10 @@ packages:
       yargs-parser: 20.2.9
     dev: false
 
+  /yeast/0.1.2:
+    resolution: {integrity: sha1-AI4G2AlDIMNy28L47XagymyKxBk=}
+    dev: false
+
   /yn/3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -8163,7 +10564,7 @@ packages:
     dev: false
 
   file:projects/ssi-nestjs-wallet.tgz_babel-jest@26.6.3:
-    resolution: {integrity: sha512-pMNFdcYMmA8CfiHo/O9pyBeElYsv500F64UFg/3Ad8LyybFhE+Grh6rTysBc95d8rI+hCPyq9vtNQVjisXJZQw==, tarball: file:projects/ssi-nestjs-wallet.tgz}
+    resolution: {integrity: sha512-DkNtlYB/46fWPLbWh2hObhrTvX51EIhZuERTae8d1DOCPaUyUFiROl9KRb9UH3ggcSuFUn1s4rfDDkkRoUl2zw==, tarball: file:projects/ssi-nestjs-wallet.tgz}
     id: file:projects/ssi-nestjs-wallet.tgz
     name: '@rush-temp/ssi-nestjs-wallet'
     version: 0.0.0
@@ -8193,8 +10594,14 @@ packages:
       eslint: 7.32.0
       eslint-config-prettier: 8.3.0_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_6e975bd57c7acf028c1a9ddbbf60c898
+      interface-blockstore: 2.0.2
+      interface-store: 2.0.1
+      ipfs-core: 0.13.0
+      ipfs-core-types: 0.9.0
+      ipfs-unixfs-importer: 9.0.6
       jest: 27.0.6_ts-node@10.4.0
       jose: 4.1.5
+      multiformats: 9.6.2
       prettier: 2.4.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2
@@ -8215,6 +10622,7 @@ packages:
       - '@sap/hana-client'
       - '@swc/core'
       - '@swc/wasm'
+      - abort-controller
       - babel-jest
       - bufferutil
       - cache-manager
@@ -8228,6 +10636,7 @@ packages:
       - mongodb
       - mssql
       - mysql2
+      - node-fetch
       - node-notifier
       - oracledb
       - pg

--- a/rush.json
+++ b/rush.json
@@ -120,7 +120,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0",
+  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || 16.10.0",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases

--- a/ssi-wallet-architecture.drawio.svg
+++ b/ssi-wallet-architecture.drawio.svg
@@ -1,13 +1,13 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="651px" height="561px" viewBox="-0.5 -0.5 651 561" content="&lt;mxfile&gt;&lt;diagram id=&quot;Is1ddiXRfVFFFKM2G-K4&quot; name=&quot;Page-1&quot;&gt;7VvbcqM4EP0aV808xMXFgHnMzTPZmdlNbaoyM48yCMwGI48QcbJfv5KQuEm+JJZ3k02cVAKNBKhPq/t0Sx6558uHTxisFt9QDPORY8UPI/di5Dhh6NC/TPBYCyaeVwtSnMW1yG4FN9nfUAgtIa2yGJa9hgShnGSrvjBCRQEj0pMBjNG63yxBef+pK5BCRXATgVyVfs9isqilU89q5Z9hli7kk21LXFkC2VgIygWI0bojci9H7jlGiNRHy4dzmDPdSb3U/WYbrjYvhmFB9ukggLgHeSXG9jssyW83VPYd5Dkk4jXJoxw7RlURQ9bdHrln60VG4M0KROzqmoJNZQuyzMXle4hJRvV2mmdpQWUEsQYJKsg5yhHmd3TrD5WXBKM72Lni8w/rkeV5Rz7z2A+Vq8MVGmAPhg8dkRj+J4iWkOBH2kRcdQUSwhQlhusWV38iZIsOphOJIBC2lDZ3btVND4TG9dr3HUW9MKaWJk4RJguUogLkl630rAXAomdtm6+IKZer/S9IyKOYNqAiqA8KfMjID9GdHf9kx2PHE6cXD51rF4/ypKBj+yHvwE7qboEnz9t+/Ex2VEC1+M828EpU4UjowxfTG+AUylZC80xVWxHGMAcku+9PWh1evOspxuCx02CFsoKUnTtfM0HHcJy+5UhLmm1qbx/W3vbtgW3Vb9xaWjP0vYwvmG41vgIVcB+7eZ7ZHGo1A+yfY0audaDV7D3LFR/7BbIH0bBYUVUfw8H23WUM4DSJtA42msJ5orpki38MOdjhPHE8xcU6OhcbGvCwgaL703uQ5WDOFG9RHEpF/zQkr9hh9JhnFAjs7kZhXkP2dd4IQHSXciD/qAi9DRTysvbJtrcvdNCOPRjooAv9wAW+Brqd7nV/6CbTocsKxip4gQa7wAB2oYLdrCoikqGC3vR05Pg5YarG9ChlRyc1ovTvJ1hADFjLba1uCMKM6DmzP+mrZZA+SDEGqijSx7oPhPCSXdSECAhYc5gQDdrLLI55ONeZVj/EH3Nuul4f4IkOYNvVIOyZmJ3+M0OQPH4adbHGFp8ZnTjk7IhD/Owa4oyODWIzlEbG9W4wmkxMc5p9MZBv05lmt7STdXp99XZilN/3c5IadSOUbg7YtoFJYNsKALv9XAeiq7KsIN7Z7DNNcvdodkttPclYw7flCf3G8Um6bWkcoXckR+ht5+LHTgQbEv+z6z93OdOGw/8cdfj9Bke6l2d0NZ7RfLa3d3Syt4KyJUF6gj4PjCUvS2OuGksuri5eeBgxyJcHYaRBYmccMVFMcl1F+d1chwJBcx36nLPGy0eCIlvfIPUd8XsqtAVaOxwGCMf1NFx56qnwTkMD6E6ewRLqybcrG6pbabOhzc2/gjmkaKavgieYnOKKGUz2TJhMpMQyXetYgQSJjXnEljzksP1fFVtFOONEKQzZEkQrquG8WeEqEs7hS0bkrehb1HerWx3mtnegqvfiHpzGE91Unzpz19dNdYNUMBgQQS8cByrGoQZix5HGcRDI0w1R9LrCK1TCFx5PJRIxKBfNu5gPrq5mpUYfXC0TE08tRp3Xi4vcAb9NRIaVXS0k+squiXkyUUPiZZ6BTkr8jgpjH7YCSrO0ZJyETtQAtZumXBUJwktJRgGlkCySgSZDoX0X2YqeziFZQ1jw51EF8UKFylr/5wzEHaxYu4Gji0/NFoPeqrWJaaeuZ+3BRGHCqL/TISF1TFvVMa1s5WMqvRyn7N9pQzeXfGkWFTlfoY0iuJImUlbzkm1TsFDC6A+G3DJAzpxynt31nzkHhECuTIJGYrtJhxW9AkM6Hs/ZZEeWxo58EzWv59Q9uWdXcKbugxlN7fwrzpAiUBuV5h4iH+pbxnlzQyr+I0l4qbSly/ve5lfFzavtKd4to+8NCs61b6/fmqG5zoBR244mc3YsTepsorjqTxSF/6vFVcsLO+XAEyqQ13eVWEdP2jPBbmJ4qcqVu+uUfRMmy4vP2n4zGdTaAmtgE4ftjnFV71SW2UnMAoaJdDiiamcobaCXT098j7hFbkAoPU1Z09XRfCOZl6eWNaU/Lleg6EEh3a4ogjD6gNP5B4u7aLbG1Tn6qJZDdOGHvl79GFkLaUOBuQcfa0BtuS7t1ACtBKMlp17zegOMRdv5YMnsTr5OfVbMy1Xn9TbowmDlqY2wG2tRx9NUt05as0ltmZyxkPhgpT19ADabCVuGsLmY97oN+KrIBC3DsER51QWoNu4LFDEr/gA2jLksUZT1gL1nwDa4LuXyR50V0Jt+fBUUzeROr4GL1+zRc3UJZWAgofT/48Xv4Bmr34a3s+7aveqpNMx/ESzMm0613GDTpmYvtA5qLzNPUzTPV+tVazc9WcP53VKTPh7G/V7BtyEm1gAfed5N1HS7YIxwPV8tLb1zvSeEymuM7vk3o6hKWXqRAE4IyhWMujwmQrzgyldvecgzSPd4NrJx0Kw+s8Aw6fVbELKqYZjR37UbnURROk4zsqjm4wwxmZyOg9s+oaccEdhJMN9Y4LeHDllTmTnWcnbgKPOdF/gYvb49f9+PsnU/ijvcsKhJy6dNoc109TbYnJZ3p5Ooyd4ID0QPv6KU/X8hOw2SBPqRdt0uDsK5pZl8s1kYuoZA9Aa0e7rflytcA6Q7UInPacR44kmSs+/HNjvFrjmH/FXBkrxPyG1YOtPxcOeIJOndbSPaGfkMZ0pP268J18y3/a61e/kP&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="691px" height="551px" viewBox="-0.5 -0.5 691 551" content="&lt;mxfile&gt;&lt;diagram id=&quot;Is1ddiXRfVFFFKM2G-K4&quot; name=&quot;Page-1&quot;&gt;7VxZc9woEP41U5U8eEoSuubR8ZF4k+y61lU5HhkJabTRiImEPPb++gUEumAOe5jEXtvZWkstQNBf0/3RIE/A2fLufQlXi884RvnEseK7CTifOI5tOSH9xST3jcQHQpCWWSwKdYKb7F8kawppncWoGhQkGOckWw2FES4KFJGBDJYlXg+LJTgfvnUFU6QIbiKYq9KvWUwWjTT0rE7+AWXpQr7ZtsSTJZSFhaBawBiveyJwMQFnJcakuVrenaGcKU/qpal3ueFp27ESFWSfCk5T4RbmtRjbn6gif9xQ2VeY54iIbpJ7OfYS10WMWHV7At6tFxlBNysYsadrijaVLcgyF49vUUkyqrfTPEsLKiOYFUhwQc5wjkveImh+qLwiJf6Bek98/sNqZHnek1967B+Vq8MVGmAvRnc9kRj+e4SXiJT3tIh4CgQSwhQlhusOV98VskUPU1ciCIUtpW3LnbrphdC4Xvu+o6gXxdTSxC0uyQKnuID5RSd91wFg0buuzCfMlMvV/g8i5F5MG1gTPAQF3WXkm6jOrr+z66njidvzu96z83t5U9CxfZMtsJumWuDJ+64ev5MVFVAt/m8beBWuy0jowxfTG5YpkqWE5pmqtiJcohyS7HY4aXV48aqnZQnvewVWOCtI1Wv5mgl6huMMLUda0uWm8vZh5W3fHtlW0+PO0tqh72V8QbjV+ApcoH3s5nFm8+utBhi3mr1nueJjPyL2IhoXa6rqYzjYobuMIQqTSOtgoxDNE9UlW/zHkIMdzxPqacYu1tG52JkBDxsouj+9hVkO50zxFsWhUvRPQ/KKXUb3eUaBKMFuFOYNZJ/mrQBGP1IO5F81oc0gIa8an2x7+0KH7NhDgQ66mR8A6Gug2zlR9ofODccuK5iq4AUa7AID2M0U7C7rIiIZLmijpxPHzwlTdUmvUnZ10iBK//8eFaiErOS2UjcEl4zoOZd/065liL5IMQaqKDLEegiE8JJ91IQIClhzlBAN2sssjnk415nWMMQfc24CbwiwqwPYBhqEPROz039kCJLXD6Mu1tTiM6MXh5wdcYjfXaMyo2NDpZngJON6Pzq57u+KTrI3vWn2hVayTq+vXk6M8od+TlKjfoTSzQHbNjAJbFsBYLef60F0VVU1KncW+0AXuXsU+0JtPclYwZflCf3W8Um6bWkcoXckR+ht5+LHXgi2JP5733/ucqYth/8+6fH7DY50L88INJ7R/Gpv7+hkbwVlywLpAfo8MJY8LY0BNZacX50/8TBikC+PwkiLxM44YiKZBICi/P5ahwJB1zr0Pe9aLx8Jimx9RtR3xK9LoS3Q2rNxgHCAp+HKoafCG84MoOs+giU0k2/XaqgppV0NbS7+Cc4RRTN9FjzB5BRXzMDdc8FkYkksl2s9K5AgsTFP2JaHHLb/s2a7CO84UZrN2BZEJ2rgvFmVdSScw8eMyKZoL5rWmlKHue0dqOq9uIfC2NVN9dCZA1831Q1SwWBEBL3ZNFAxnmkgdhxpHAeBHG6Iotd1ucIVeuLxVCIRw2rR9sV8cAWanRp9cLVMTDw1GXXWbC5yB/wyERlndnWQaJdMRiBx1Yh4kWewtyJ+BYWRD1vBpN1ZMs5BXTU+7WYpV0WCy6XkopAySBbIYLtAoXUX2YrezhFZI1Tw91EF8TyFSlr/5wQEjDasQeDowpOt21HxjcQnV93Q2oOKooRxf6fHQpqgtmqCWtXJp1R6MU3Zr9OWby753iwucr5FG0VoJY2kqucVO6dg4YTxnxJx24A588p59mP4zjkkBHF1EjwR5016tOgZmNLxiM4GS3IsnSWZSHo9JvHJfbuCM3UgzGga919zihTBxqg0bYgF0dAyztoGqfivJOG50o4v79vMz5qbV1dT9C2j/YYFJ9tfrl+aoQFnRKltR7N0dizN2tlEdtV3FYX/0uyq5c16+cATKpDPd+VYJw86NMEaMbxXBeTxuqOepHjU+Rt3lGwLrJFNHHY8Bqjeqaqyk5gFDBPr4YiqnaG0gWA+fOV7xDNyI0rpWSrPBzq+YYTne2peU/rjagWLARTS7YosCKMPZTp/Y3EXzTa5eldv1XyILvzQ7jWvkcmQLhSYe/GxBtTl69JeEtBKSrzk1GvenICxaDkfLpndye40d8W8WvW6t0EXBlNPXYTdmIw6nqb6idKGTWrz5IyFxAcr7eEDsNlM2DKEzdm8523AV0UmaFmJKpzXfYAa4z7HEbPiN3DDmKsKR9kA2FsGbIvrUu5/NKsC2ujbZ0HRTB71Grl4W+VnbWZhkNU2sKD0f/Pud/CI7e9ffJ7VU2mY/yRYmD/iBvLI4KZTzb53WHnTNM9XM1ZrkJ6s0fzHUrN8PIz7PYPPIdxg5Ag0XE+bETDC9Xw1tfTK9R4QKq9LfMs/jaIqZcuLBHJCUK1Q1OcxEeYpV759y0OeQbrHVyMbB83yM4sSJYN6C0JWDQyX9L81iE6iKJ2mGVnU82mGmUxOx1GzD6gpRwR3EswXFvhHZ7w9RzPhj7WfHTjKfOcJPkavv5y9HkjZeiAFjE8sao4bhW2izXT2Nti8LO9PJ5GTvREeiF5+win7/USOGiQJ8iPtzl0czOaWZvJdXs5mwBCI3oh2h/t9XQEMkO5AJT6nEeOJJ0nOPpBtj4pdcw75s0YVeZ2Q27B0wun46Igk6f1zI9oZacKZSkfed6Z8S4OwXn6o55PnsSO+QfEaeDYHtZk7xkJ7OMHVgmGEyoZqaNu9uxVDwrc05Vm8JlkhpHwhx0Mjz1IwUUrnazGRaZA3qNk1pcwsFydTnmMe4yDkPcubOnvtax5xhzz8zRtOj0loWNNw5vaTGvbUAu3XUg9Oa2g/nJroMhY7kx/Sr6nfS/3yZIflDC3L3Z688GbBtvLD5IX6tvGfJhh/bdQoSdTa1o3Rmr7VqGyo0azS0O50Cr3t/lZFU7z7ix/g4j8=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="10" y="0" width="640" height="420" rx="63" ry="63" fill="#f5f5f5" stroke="#666666" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 638px; height: 1px; padding-top: 7px; margin-left: 11px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 NestJS Wallet
                             </div>
                         </div>
@@ -25,10 +25,10 @@
         <rect x="300" y="175" width="240" height="90" rx="13.5" ry="13.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 182px; margin-left: 301px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Key Module
                             </div>
                         </div>
@@ -43,10 +43,10 @@
         <path d="M 530 202.5 C 530 210.78 514.33 217.5 495 217.5 C 475.67 217.5 460 210.78 460 202.5" fill="none" stroke="#9673a6" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 68px; height: 1px; padding-top: 225px; margin-left: 461px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Available Keys
                             </div>
                         </div>
@@ -60,10 +60,10 @@
         <rect x="315" y="197.5" width="130" height="50" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 128px; height: 1px; padding-top: 223px; margin-left: 317px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - Key Generation
@@ -83,10 +83,10 @@
         <rect x="40" y="28" width="230" height="110" rx="16.5" ry="16.5" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 228px; height: 1px; padding-top: 35px; margin-left: 41px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 VC API Module
                             </div>
                         </div>
@@ -100,10 +100,10 @@
         <rect x="47.5" y="55" width="150" height="50" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 148px; height: 1px; padding-top: 80px; margin-left: 50px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - VC API Issuer
@@ -120,17 +120,17 @@
                 </text>
             </switch>
         </g>
-        <path d="M 155 160 L 155 144.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 155 139.12 L 158.5 146.12 L 155 144.37 L 151.5 146.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 155 160 L 155 144.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 155 139.12 L 158.5 146.12 L 155 144.37 L 151.5 146.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
         <path d="M 155 160 L 155 144.37" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 155 139.12 L 158.5 146.12 L 155 144.37 L 151.5 146.12 Z" fill="#030303" stroke="#030303" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="40" y="160" width="230" height="120" rx="18" ry="18" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 228px; height: 1px; padding-top: 167px; margin-left: 41px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 DID Module
                             </div>
                         </div>
@@ -145,10 +145,10 @@
         <path d="M 262.5 200.5 C 262.5 208.78 243.47 215.5 220 215.5 C 196.53 215.5 177.5 208.78 177.5 200.5" fill="none" stroke="#9673a6" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 83px; height: 1px; padding-top: 223px; margin-left: 179px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Available DIDs + Verification Methods
                             </div>
                         </div>
@@ -162,10 +162,10 @@
         <rect x="47.5" y="195" width="130" height="70" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 128px; height: 1px; padding-top: 230px; margin-left: 50px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - DID Generation
@@ -185,10 +185,10 @@
         <rect x="55" y="109.75" width="90" height="22.5" rx="3.38" ry="3.38" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 88px; height: 1px; padding-top: 117px; margin-left: 57px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font color="#009900">
                                     Spruce DIDKit
                                 </font>
@@ -204,10 +204,10 @@
         <rect x="40" y="300" width="230" height="100" rx="15" ry="15" fill="#dae8fc" stroke="#6c8ebf" stroke-dasharray="3 3" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 228px; height: 1px; padding-top: 307px; margin-left: 41px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 DID Purpose Module
                             </div>
                         </div>
@@ -218,19 +218,19 @@
                 </text>
             </switch>
         </g>
-        <rect x="300" y="300" width="240" height="90.5" rx="13.57" ry="13.57" fill="#dae8fc" stroke="#6c8ebf" stroke-dasharray="3 3" pointer-events="all"/>
+        <rect x="300" y="300" width="150" height="100" rx="15" ry="15" fill="#dae8fc" stroke="#6c8ebf" stroke-dasharray="3 3" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 307px; margin-left: 301px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 148px; height: 1px; padding-top: 307px; margin-left: 301px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Connections Module
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="420" y="319" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="375" y="319" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Connections Module
                 </text>
             </switch>
@@ -238,10 +238,10 @@
         <rect x="300" y="31" width="310" height="120" rx="18" ry="18" fill="#dae8fc" stroke="#6c8ebf" stroke-dasharray="3 3" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 308px; height: 1px; padding-top: 38px; margin-left: 301px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Elia Issuer Module
                             </div>
                         </div>
@@ -252,13 +252,13 @@
                 </text>
             </switch>
         </g>
-        <rect x="310" y="322.75" width="220" height="45" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="310" y="322.75" width="140" height="62.5" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 218px; height: 1px; padding-top: 345px; margin-left: 312px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 138px; height: 1px; padding-top: 354px; margin-left: 312px;">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - Information about a relationship between identifiers
@@ -266,7 +266,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="312" y="349" fill="#030303" font-family="Helvetica" font-size="12px">
+                <text x="312" y="358" fill="#030303" font-family="Helvetica" font-size="12px">
                     Functions:...
                 </text>
             </switch>
@@ -274,10 +274,10 @@
         <rect x="55" y="322.75" width="200" height="60" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 198px; height: 1px; padding-top: 353px; margin-left: 57px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - Define "DID purposes". E.g. A DID may only accept a subset of credentials like "battery to grid"
@@ -293,10 +293,10 @@
         <rect x="305" y="62.5" width="205" height="50" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 203px; height: 1px; padding-top: 88px; margin-left: 307px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Functions:
                                 <br/>
                                 - Issue credentials for Elia use cases
@@ -313,32 +313,32 @@
                 </text>
             </switch>
         </g>
-        <path d="M 20.06 459 L 20.1 220 L 33.63 220" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 20.06 449 L 20.1 220 L 33.63 220" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
         <path d="M 38.88 220 L 31.88 223.5 L 33.63 220 L 31.88 216.5 Z" fill="#030303" stroke="#030303" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="0" y="460" width="340" height="100" rx="15" ry="15" fill="#f5f5f5" stroke="#82b366" pointer-events="all"/>
+        <rect x="0" y="450" width="340" height="100" rx="15" ry="15" fill="#f5f5f5" stroke="#82b366" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 338px; height: 1px; padding-top: 467px; margin-left: 1px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 338px; height: 1px; padding-top: 457px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 ssi-did
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="170" y="479" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="170" y="469" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     ssi-did
                 </text>
             </switch>
         </g>
-        <rect x="20" y="475" width="320" height="75" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="20" y="465" width="320" height="75" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 318px; height: 1px; padding-top: 513px; margin-left: 22px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 318px; height: 1px; padding-top: 503px; margin-left: 22px;">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <span style="color: rgb(0 , 0 , 0)">
                                     Functions:
                                 </span>
@@ -365,38 +365,38 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="22" y="516" fill="#030303" font-family="Helvetica" font-size="12px">
+                <text x="22" y="506" fill="#030303" font-family="Helvetica" font-size="12px">
                     Functions:...
                 </text>
             </switch>
         </g>
-        <path d="M 567.5 450 L 567.5 460 L 570 460 L 570 210 L 540 210 L 540 213.63" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 540 218.88 L 536.5 211.88 L 540 213.63 L 543.5 211.88 Z" fill="#030303" stroke="#030303" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="380" y="450" width="250" height="100" rx="15" ry="15" fill="#f5f5f5" stroke="#666666" pointer-events="all"/>
+        <path d="M 600 450 L 600 430 L 630 430 L 630 220 L 546.37 220" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 541.12 220 L 548.12 216.5 L 546.37 220 L 548.12 223.5 Z" fill="#030303" stroke="#030303" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="450" y="450" width="200" height="100" rx="15" ry="15" fill="#f5f5f5" stroke="#666666" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 457px; margin-left: 381px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 198px; height: 1px; padding-top: 457px; margin-left: 451px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 w3g-webkms
                                 <br/>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="505" y="469" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="550" y="469" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     w3g-webkms
                 </text>
             </switch>
         </g>
-        <rect x="390" y="465" width="230" height="70" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="460" y="470" width="230" height="70" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 228px; height: 1px; padding-top: 500px; margin-left: 392px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 228px; height: 1px; padding-top: 505px; margin-left: 462px;">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <span style="color: rgb(0 , 0 , 0)">
                                     Functions:
                                 </span>
@@ -413,7 +413,7 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="392" y="504" fill="#030303" font-family="Helvetica" font-size="12px">
+                <text x="462" y="509" fill="#030303" font-family="Helvetica" font-size="12px">
                     Functions:...
                 </text>
             </switch>
@@ -422,10 +422,10 @@
         <path d="M 256 75 C 256 83.28 237.53 90 214.75 90 C 191.97 90 173.5 83.28 173.5 75" fill="none" stroke="#9673a6" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 81px; height: 1px; padding-top: 97px; margin-left: 175px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Issued VCs
                             </div>
                         </div>
@@ -439,10 +439,10 @@
         <rect x="520" y="35" width="70" height="35" rx="5.25" ry="5.25" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 68px; height: 1px; padding-top: 42px; margin-left: 522px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FF9933; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #FF9933; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 153, 51); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font>
                                     Elia Specific Logic
                                 </font>
@@ -459,10 +459,10 @@
         <path d="M 601.25 91 C 601.25 99.28 580.54 106 555 106 C 529.46 106 508.75 99.28 508.75 91" fill="none" stroke="#9673a6" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 91px; height: 1px; padding-top: 113px; margin-left: 510px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #030303; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 Active-flows + VP requests
                             </div>
                         </div>
@@ -473,6 +473,44 @@
                 </text>
             </switch>
         </g>
+        <rect x="474.75" y="300" width="142.5" height="100" rx="15" ry="15" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 141px; height: 1px; padding-top: 307px; margin-left: 476px;">
+                        <div data-drawio-colors="color: #000000; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Identity Hub Module
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="546" y="319" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Identity Hub Module
+                </text>
+            </switch>
+        </g>
+        <rect x="485.25" y="322.75" width="140" height="62.5" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 138px; height: 1px; padding-top: 354px; margin-left: 487px;">
+                        <div data-drawio-colors="color: #030303; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(3, 3, 3); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Functions:
+                                <br/>
+                                - data storage of data related to a given DID (e.g. collections)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="487" y="358" fill="#030303" font-family="Helvetica" font-size="12px">
+                    Functions:...
+                </text>
+            </switch>
+        </g>
+        <path d="M 581.63 300 L 581.6 290 L 577.1 290 L 577.14 161.33" fill="none" stroke="#030303" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 577.14 156.08 L 580.64 163.08 L 577.14 161.33 L 573.64 163.08 Z" fill="#030303" stroke="#030303" stroke-miterlimit="10" pointer-events="all"/>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>


### PR DESCRIPTION
In order to persist issued and held credentials (for presentation, to move #25 forward), this PR add an `identity-hub` module, which is a very simple, partial, implementation of the DIF Identity Hub [Collections interface](https://identity.foundation/identity-hub/spec/#collections).

For a diagram of how Identity Hub can fit into a confidential storage layer, see https://identity.foundation/edv-spec/#ecosystem-overview

Currently, there is only a `service`. No HTTP API is planned for this module at this point.

The `service` API is currently only processing of [CollectionsQuery](https://identity.foundation/identity-hub/spec/#query) and [CollectionsWrite](https://identity.foundation/identity-hub/spec/#write-2) messages.