### PR TITLE
feat: add callback to exchange configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ sequenceDiagram
 
   rect rgb(255, 243, 255)
   note right of R: submit presentation
-    RSB->>R: display required presentation data
+    RSB->>RSH: request VCs based on credential query
+    activate RSH
+    RSH-->>RSB: return VCs that could match credential query 
+    deactivate RSH
+    RSB->>R: display VP request with possible VCs
     R-->>RSB: enter required input and/or select credentials
     RSB->>R: request credential application (presentation) signature
     R-->>RSB: approve signature
@@ -155,6 +159,9 @@ sequenceDiagram
       RSB->>ISH: query presentation review status
       alt presentation is processed
         ISH-->>RSB: return review result (possibly including VP with VC)
+        opt
+          ISH->>ISH: execute configured notifications
+        end
       else presentation not yet processed
         ISH-->>RSB: return "mediation in progress" VP Request
       end
@@ -167,6 +174,9 @@ sequenceDiagram
     activate ISH
       ISH->>ISH: Verify presentation signatures and satisfaction of credential query
       ISH-->>RSB: return review result 
+      opt
+        ISH->>ISH: execute configured notifications
+      end
     deactivate ISH
   end
   end

--- a/apps/nestjs-wallet/package.json
+++ b/apps/nestjs-wallet/package.json
@@ -43,7 +43,8 @@
     "@nestjs/swagger": "~5.1.5",
     "swagger-ui-express": "~4.1.6",
     "uuid": "~8.3.2",
-    "@sphereon/pex": "~1.0.2"
+    "@sphereon/pex": "~1.0.2",
+    "@nestjs/axios": "~0.0.7"
   },
   "devDependencies": {
     "@nestjs/cli": "^8.0.0",
@@ -65,7 +66,9 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "nock": "~13.2.4",
+    "axios": "~0.26.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/callback-configuration.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/callback-configuration.dto.ts
@@ -1,0 +1,10 @@
+import { IsUrl } from 'class-validator';
+import { CallbackConfiguration } from '../types/callback-configuration';
+
+/**
+ * An exchange result callback
+ */
+export class CallbackConfigurationDto implements CallbackConfiguration {
+  @IsUrl()
+  url: string;
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
@@ -1,6 +1,7 @@
 import { IsBoolean, IsString, ValidateNested } from 'class-validator';
 import { VpRequestQueryDto } from './vp-request-query.dto';
 import { ExchangeInteractServiceDefinitionDto } from './exchange-interact-service-definition.dto';
+import { CallbackConfigurationDto } from './callback-configuration.dto';
 
 /**
  * A exchange definition
@@ -17,4 +18,7 @@ export class ExchangeDefinitionDto {
 
   @IsBoolean()
   isOneTime: boolean;
+
+  @ValidateNested({ each: true })
+  callback: CallbackConfigurationDto[];
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.ts
@@ -5,6 +5,7 @@ import { TransactionEntity } from './transaction.entity';
 import { VpRequestInteractServiceDefinition } from '../types/vp-request-interact-service-definition';
 import { VpRequestInteractServiceType } from '../types/vp-request-interact-service-type';
 import { VpRequestEntity } from './vp-request.entity';
+import { CallbackConfiguration } from '../types/callback-configuration';
 
 /**
  * A TypeOrm entity representing an exchange
@@ -42,6 +43,12 @@ export class ExchangeEntity {
   query: VpRequestQuery[];
 
   /**
+   * Location where vc-api will notify exchange issuer/verifier of exchange result
+   */
+  @Column('simple-json')
+  callback: CallbackConfiguration[];
+
+  /**
    * Create transaction associated with this exchange.
    *
    * Transactions are created by exchange (exchange is the aggregate root) because the exchange may want to enforce invariants such as
@@ -70,7 +77,7 @@ export class ExchangeEntity {
         service: interactServices
       }
     };
-    const transaction = new TransactionEntity(transactionId, this.exchangeId, vpRequest);
+    const transaction = new TransactionEntity(transactionId, this.exchangeId, vpRequest, this.callback);
     return transaction;
   }
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.spec.ts
@@ -1,4 +1,6 @@
+import { VpRequestInteractServiceType } from '../types/vp-request-interact-service-type';
 import { TransactionEntity } from './transaction.entity';
+import { VpRequestEntity } from './vp-request.entity';
 
 describe('TransactionEntity', () => {
   beforeEach(async () => {});
@@ -7,21 +9,37 @@ describe('TransactionEntity', () => {
     jest.resetAllMocks();
   });
 
-  describe('process presentation', () => {
-    it('should validate VP submission credential query of VP Request', async () => {
-      const vp = {};
-      const vpRequest = {};
-      // const transaction = new TransactionEntity();
-      // transaction.processPresentation(vp);
-    });
-
-    it('should return VP Request with Mediated ServiceEndpoint', async () => {
-      const vp = {};
-      const vpRequest = {};
-      // const transaction = new TransactionEntity();
-      // const result = transaction.processPresentation(vp);
-      const result = {};
-      expect(result);
+  describe('processPresentation', () => {
+    it('should return result upon successful verification of UnMediatedPresentation', async () => {
+      const vp = {
+        '@context': [],
+        type: [],
+        verifiableCredential: [],
+        proof: {}
+      };
+      const vpRequest: VpRequestEntity = {
+        challenge: 'a9511bdb-5577-4d2f-95e3-e819fe5d3c33',
+        query: [],
+        interact: {
+          service: [
+            {
+              type: VpRequestInteractServiceType.unmediatedPresentation,
+              serviceEndpoint: 'https://endpoint.com'
+            }
+          ]
+        }
+      };
+      const callback_1 = 'https://my-callback.com';
+      const configuredCallback = [{ url: callback_1 }];
+      const exchangeId = 'my-exchange';
+      const transactionId = '9ec5686e-6381-41c4-9286-3c93cdefac53';
+      const transaction = new TransactionEntity(transactionId, exchangeId, vpRequest, configuredCallback);
+      const { callback, response } = transaction.processPresentation(vp);
+      expect(callback).toHaveLength(1);
+      expect(callback[0].url).toEqual(callback_1);
+      expect(response.errors).toHaveLength(0);
+      expect(response.vpRequest).toBeUndefined();
+      expect(response.vp).toBeUndefined();
     });
   });
 });

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule } from '@nestjs/axios';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
 import { TypeOrmSQLiteModule } from '../../in-memory-db';
 import { Repository } from 'typeorm';
@@ -30,7 +31,8 @@ describe('ExchangeService', () => {
           ExchangeEntity,
           TransactionEntity,
           PresentationReviewEntity
-        ])
+        ]),
+        HttpModule
       ],
       providers: [
         ExchangeService,
@@ -63,7 +65,7 @@ describe('ExchangeService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('create exchange', () => {
+  describe('createExchange', () => {
     it('should accept a presentation definition in an exchange definition', async () => {
       const presentationDefinition = {
         id: '57ca126c-acbf-4da4-8f79-447150e93128',
@@ -89,14 +91,15 @@ describe('ExchangeService', () => {
             baseUrl: 'https://example.org/'
           }
         ],
-        isOneTime: false
+        isOneTime: false,
+        callback: []
       };
       const result = await service.createExchange(exchangeDef);
       expect(result.errors).toHaveLength(0);
     });
   });
 
-  describe('start exchange', () => {
+  describe('startExchange', () => {
     it('should start exchange from an exchange definition', async () => {
       const exchangeId = 'test-exchange';
       const exchangeDef: ExchangeDefinitionDto = {
@@ -107,7 +110,8 @@ describe('ExchangeService', () => {
           }
         ],
         query: [],
-        isOneTime: false
+        isOneTime: false,
+        callback: []
       };
       await service.createExchange(exchangeDef);
       const exchangeResponse = await service.startExchange(exchangeId);

--- a/apps/nestjs-wallet/src/vc-api/exchanges/types/callback-configuration.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/types/callback-configuration.ts
@@ -1,0 +1,6 @@
+/**
+ * A callback to execute after an exchange
+ */
+export interface CallbackConfiguration {
+  url: string;
+}

--- a/apps/nestjs-wallet/src/vc-api/vc-api.module.ts
+++ b/apps/nestjs-wallet/src/vc-api/vc-api.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DidModule } from '../did/did.module';
@@ -16,7 +17,8 @@ import { PresentationReviewEntity } from './exchanges/entities/presentation-revi
     DidModule,
     KeyModule,
     TypeOrmModule.forFeature([VpRequestEntity, ExchangeEntity, TransactionEntity, PresentationReviewEntity]),
-    ConfigModule
+    ConfigModule,
+    HttpModule
   ],
   controllers: [VcApiController],
   providers: [CredentialsService, ExchangeService],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@nestjs/axios': ~0.0.7
   '@nestjs/cli': ^8.0.0
   '@nestjs/common': ^8.0.0
   '@nestjs/config': ~1.1.0
@@ -24,7 +25,7 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^4.28.2
   '@typescript-eslint/parser': ^4.28.2
   babel-jest: 26.6.3
-  better-sqlite3: ~7.4.4
+  better-sqlite3: ~7.5.0
   class-transformer: ~0.4.0
   class-validator: ~0.13.1
   did-resolver: ~3.1.3
@@ -35,6 +36,7 @@ specifiers:
   ethr-did-resolver: ~5.0.2
   jest: 27.0.6
   jose: ^4.1.5
+  nock: ~13.2.4
   prettier: ^2.3.2
   reflect-metadata: ^0.1.13
   rimraf: ^3.0.2
@@ -50,6 +52,7 @@ specifiers:
   uuid: ~8.3.2
 
 dependencies:
+  '@nestjs/axios': 0.0.7_b3e6921aee41404e2866237bfdfd83a3
   '@nestjs/cli': 8.1.4_eslint@7.32.0
   '@nestjs/common': 8.1.2_43f93dd897e68fe834a23ddd32fb54cc
   '@nestjs/config': 1.1.0_b3e6921aee41404e2866237bfdfd83a3
@@ -73,7 +76,7 @@ dependencies:
   '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
   '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
   babel-jest: 26.6.3
-  better-sqlite3: 7.4.4
+  better-sqlite3: 7.5.0
   class-transformer: 0.4.0
   class-validator: 0.13.1
   did-resolver: 3.1.3
@@ -84,6 +87,7 @@ dependencies:
   ethr-did-resolver: 5.0.2
   jest: 27.0.6_ts-node@10.4.0
   jose: 4.1.5
+  nock: 13.2.4
   prettier: 2.4.1
   reflect-metadata: 0.1.13
   rimraf: 3.0.2
@@ -94,7 +98,7 @@ dependencies:
   ts-loader: 9.2.6_typescript@4.4.4
   ts-node: 10.4.0_0cb88d80cb04d25b21fa3ec194608c65
   tsconfig-paths: 3.11.0
-  typeorm: 0.2.38_better-sqlite3@7.4.4
+  typeorm: 0.2.38_better-sqlite3@7.5.0
   typescript: 4.4.4
   uuid: 8.3.2
 
@@ -1202,6 +1206,21 @@ packages:
     resolution: {integrity: sha512-WrHvO8PDL8wd8T2+zBGKrMwVL5IyzR3ryWUsl0PXgEV0QHup4mTLi0QcATefGI6Gx9Anu7vthPyyyLpY0EpiQg==}
     dev: false
 
+  /@nestjs/axios/0.0.7_b3e6921aee41404e2866237bfdfd83a3:
+    resolution: {integrity: sha512-at8nj+1Nb8UleHcIN5QqZYeWX54m4m9s9gxzVE1qWy00neX2rg0+h2TfbWsnDi2tc23zIxqexanxMOJZbzO0CA==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0
+      reflect-metadata: ^0.1.12
+      rxjs: ^6.0.0 || ^7.0.0
+    dependencies:
+      '@nestjs/common': 8.1.2_43f93dd897e68fe834a23ddd32fb54cc
+      axios: 0.26.0
+      reflect-metadata: 0.1.13
+      rxjs: 7.4.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@nestjs/cli/8.1.4_eslint@7.32.0:
     resolution: {integrity: sha512-QXZ0fkybNEPUeP3wcWuFore8XVicrT76IYToHkc4PJ+kQ7/thQzpy5mqWGTalv83aNM5LKAjl5OTSBBrPiWrlg==}
     engines: {node: '>= 10.13.0', npm: '>= 6.11.0'}
@@ -1429,7 +1448,7 @@ packages:
       '@nestjs/core': 8.1.2_3d1cfdac3af6acf6d20b789f19aaf219
       reflect-metadata: 0.1.13
       rxjs: 7.4.0
-      typeorm: 0.2.38_better-sqlite3@7.4.4
+      typeorm: 0.2.38_better-sqlite3@7.5.0
       uuid: 8.3.2
     dev: false
 
@@ -2471,6 +2490,14 @@ packages:
       - debug
     dev: false
 
+  /axios/0.26.0:
+    resolution: {integrity: sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==}
+    dependencies:
+      follow-redirects: 1.14.9
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /babel-jest/26.6.3:
     resolution: {integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==}
     engines: {node: '>= 10.14.2'}
@@ -2642,15 +2669,6 @@ packages:
 
   /bech32/1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
-    dev: false
-
-  /better-sqlite3/7.4.4:
-    resolution: {integrity: sha512-CnK1JjchxbEumd2J6lqfzSG5nT4B/v+J9P0AKSm3NHSfcPsEGE4rHUp9lDlslJ1TL701RM7GWlTp3Pbacpn1/Q==}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 6.1.4
-      tar: 6.1.11
     dev: false
 
   /better-sqlite3/7.5.0:
@@ -2910,11 +2928,6 @@ packages:
 
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-    dev: false
-
-  /chownr/2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
     dev: false
 
   /chrome-trace-event/1.0.3:
@@ -3251,13 +3264,6 @@ packages:
     engines: {node: '>=0.10'}
     dev: false
 
-  /decompress-response/4.2.1:
-    resolution: {integrity: sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==}
-    engines: {node: '>=8'}
-    dependencies:
-      mimic-response: 2.1.0
-    dev: false
-
   /decompress-response/6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -3334,12 +3340,6 @@ packages:
 
   /destroy/1.0.4:
     resolution: {integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=}
-    dev: false
-
-  /detect-libc/1.0.3:
-    resolution: {integrity: sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=}
-    engines: {node: '>=0.10'}
-    hasBin: true
     dev: false
 
   /detect-libc/2.0.1:
@@ -4137,6 +4137,16 @@ packages:
         optional: true
     dev: false
 
+  /follow-redirects/1.14.9:
+    resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}
     engines: {node: '>=0.10.0'}
@@ -4226,13 +4236,6 @@ packages:
       graceful-fs: 4.2.8
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
-
-  /fs-minipass/2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.1.5
     dev: false
 
   /fs-monkey/1.0.3:
@@ -5623,6 +5626,10 @@ packages:
     resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=}
     dev: false
 
+  /json-stringify-safe/5.0.1:
+    resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
+    dev: false
+
   /json5/1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
@@ -5912,11 +5919,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /mimic-response/2.1.0:
-    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
-    engines: {node: '>=8'}
-    dev: false
-
   /mimic-response/3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -5938,21 +5940,6 @@ packages:
 
   /minimist/1.2.5:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
-    dev: false
-
-  /minipass/3.1.5:
-    resolution: {integrity: sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-    dev: false
-
-  /minizlib/2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.1.5
-      yallist: 4.0.0
     dev: false
 
   /mixin-deep/1.3.2:
@@ -6062,10 +6049,16 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: false
 
-  /node-abi/2.30.1:
-    resolution: {integrity: sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==}
+  /nock/13.2.4:
+    resolution: {integrity: sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==}
+    engines: {node: '>= 10.13'}
     dependencies:
-      semver: 5.7.1
+      debug: 4.3.2
+      json-stringify-safe: 5.0.1
+      lodash.set: 4.3.2
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /node-abi/3.8.0:
@@ -6458,26 +6451,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /prebuild-install/6.1.4:
-    resolution: {integrity: sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      detect-libc: 1.0.3
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.5
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 1.0.2
-      node-abi: 2.30.1
-      npmlog: 4.1.2
-      pump: 3.0.0
-      rc: 1.2.8
-      simple-get: 3.1.0
-      tar-fs: 2.1.1
-      tunnel-agent: 0.6.0
-    dev: false
-
   /prebuild-install/7.0.1:
     resolution: {integrity: sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==}
     engines: {node: '>=10'}
@@ -6564,6 +6537,11 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: false
+
+  /propagate/2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
     dev: false
 
   /proxy-addr/2.0.7:
@@ -7040,14 +7018,6 @@ packages:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
     dev: false
 
-  /simple-get/3.1.0:
-    resolution: {integrity: sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==}
-    dependencies:
-      decompress-response: 4.2.1
-      once: 1.4.0
-      simple-concat: 1.0.1
-    dev: false
-
   /simple-get/4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
     dependencies:
@@ -7433,18 +7403,6 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /tar/6.1.11:
-    resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
-    engines: {node: '>= 10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 3.1.5
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: false
-
   /terminal-link/2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
@@ -7774,79 +7732,6 @@ packages:
 
   /typedarray/0.0.6:
     resolution: {integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=}
-    dev: false
-
-  /typeorm/0.2.38_better-sqlite3@7.4.4:
-    resolution: {integrity: sha512-M6Y3KQcAREQcphOVJciywf4mv6+A0I/SeR+lWNjKsjnQ+a3XcMwGYMGL0Jonsx3H0Cqlf/3yYqVki1jIXSK/xg==}
-    hasBin: true
-    peerDependencies:
-      '@sap/hana-client': '*'
-      better-sqlite3: '*'
-      hdb-pool: '*'
-      ioredis: '*'
-      mongodb: ^3.6.0
-      mssql: '*'
-      mysql2: '*'
-      oracledb: '*'
-      pg: '*'
-      pg-native: '*'
-      pg-query-stream: '*'
-      redis: '*'
-      sql.js: '*'
-      sqlite3: '*'
-      typeorm-aurora-data-api-driver: '*'
-    peerDependenciesMeta:
-      '@sap/hana-client':
-        optional: true
-      better-sqlite3:
-        optional: true
-      hdb-pool:
-        optional: true
-      ioredis:
-        optional: true
-      mongodb:
-        optional: true
-      mssql:
-        optional: true
-      mysql2:
-        optional: true
-      oracledb:
-        optional: true
-      pg:
-        optional: true
-      pg-native:
-        optional: true
-      pg-query-stream:
-        optional: true
-      redis:
-        optional: true
-      sql.js:
-        optional: true
-      sqlite3:
-        optional: true
-      typeorm-aurora-data-api-driver:
-        optional: true
-    dependencies:
-      '@sqltools/formatter': 1.2.3
-      app-root-path: 3.0.0
-      better-sqlite3: 7.4.4
-      buffer: 6.0.3
-      chalk: 4.1.2
-      cli-highlight: 2.1.11
-      debug: 4.3.2
-      dotenv: 8.6.0
-      glob: 7.2.0
-      js-yaml: 4.1.0
-      mkdirp: 1.0.4
-      reflect-metadata: 0.1.13
-      sha.js: 2.4.11
-      tslib: 2.3.1
-      xml2js: 0.4.23
-      yargonaut: 1.1.4
-      yargs: 17.2.1
-      zen-observable-ts: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /typeorm/0.2.38_better-sqlite3@7.5.0:
@@ -8377,12 +8262,13 @@ packages:
     dev: false
 
   file:projects/ssi-nestjs-wallet.tgz_babel-jest@26.6.3:
-    resolution: {integrity: sha512-b619oB8LfMbdTrUBBvm6dRBmZAnh9WOP+PrNHV45CFyav5jWwjpN1AXegKGvzwu/Td0rtorxn8KPYWFKwAPGCg==, tarball: file:projects/ssi-nestjs-wallet.tgz}
+    resolution: {integrity: sha512-a35cHI9XBGqCEWQQKeaiIlS3K7lg7kClMO6pz4MrueZOeRgErLd8U6zHgVxSNJpoQIKNAHTt7JJqETt4FYQcoQ==, tarball: file:projects/ssi-nestjs-wallet.tgz}
     id: file:projects/ssi-nestjs-wallet.tgz
     name: '@rush-temp/ssi-nestjs-wallet'
     version: 0.0.0
     dependencies:
       '@ew-did-registry/did': 0.6.0
+      '@nestjs/axios': 0.0.7_b3e6921aee41404e2866237bfdfd83a3
       '@nestjs/cli': 8.1.4_eslint@7.32.0
       '@nestjs/common': 8.1.2_43f93dd897e68fe834a23ddd32fb54cc
       '@nestjs/config': 1.1.0_b3e6921aee41404e2866237bfdfd83a3
@@ -8401,6 +8287,7 @@ packages:
       '@types/supertest': 2.0.11
       '@typescript-eslint/eslint-plugin': 4.33.0_cc617358c89d3f38c52462f6d809db4c
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.4.4
+      axios: 0.26.0
       better-sqlite3: 7.5.0
       class-transformer: 0.4.0
       class-validator: 0.13.1
@@ -8410,6 +8297,7 @@ packages:
       eslint-plugin-prettier: 3.4.1_6e975bd57c7acf028c1a9ddbbf60c898
       jest: 27.0.6_ts-node@10.4.0
       jose: 4.1.5
+      nock: 13.2.4
       prettier: 2.4.1
       reflect-metadata: 0.1.13
       rimraf: 3.0.2


### PR DESCRIPTION
Rebeam Jira issue: https://energyweb.atlassian.net/browse/REBDEV-74

- [x] persist callback configuration from exchange definition
- [x] execute callbacks after presentation verifications -> done in similar way to https://github.com/energywebfoundation/ssi-hub/blob/7650f8c49a874483eac2d990ba759faf53d73019/src/modules/claim/claim.controller.ts#L120
- [x] add tests (unit and e2e)
- [x] update flow diagram