### PR TITLE
feat(exchange.entity): generate txId in constructor

### DIFF
--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
@@ -12,5 +12,5 @@ export class VpRequestQueryDto {
    * TODO: Validate the queries. Maybe with a custom validator E.g. this.#pex.validateDefinition(workflowDefinition.presentationDefinition);
    */
   @IsArray()
-  credentialQuery?: any[];
+  credentialQuery: any[];
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.spec.ts
@@ -1,0 +1,34 @@
+import { ExchangeDefinitionDto } from '../dtos/exchange-definition.dto';
+import { ExchangeEntity } from './exchange.entity';
+
+describe('ExchangeEntity', () => {
+  describe('start', () => {
+    it('should respond with the same transaction id if it is a oneTime exchange', async () => {
+      const exchangeDefinition: ExchangeDefinitionDto = {
+        exchangeId: '9ec5686e-6381-41c4-9286-3c93cdefac53',
+        interactServices: [],
+        query: [],
+        callback: [],
+        isOneTime: true
+      };
+      const exchange = new ExchangeEntity(exchangeDefinition);
+      const transaction_1 = exchange.start();
+      const transaction_2 = exchange.start();
+      expect(transaction_1.transactionId).toEqual(transaction_2.transactionId);
+    });
+
+    it('should respond with different transaction id if it is not a ontTime exchange', async () => {
+      const exchangeDefinition: ExchangeDefinitionDto = {
+        exchangeId: '9ec5686e-6381-41c4-9286-3c93cdefac53',
+        interactServices: [],
+        query: [],
+        callback: [],
+        isOneTime: false
+      };
+      const exchange = new ExchangeEntity(exchangeDefinition);
+      const transaction_1 = exchange.start();
+      const transaction_2 = exchange.start();
+      expect(transaction_1.transactionId).not.toEqual(transaction_2.transactionId);
+    });
+  });
+});

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -27,7 +27,7 @@ export class TransactionEntity {
     this.transactionId = transactionId;
     this.exchangeId = exchangeId;
     this.vpRequest = vpRequest;
-    if (vpRequest?.interact?.service[0].type === VpRequestInteractServiceType.mediatedPresentation) {
+    if (vpRequest?.interact?.service[0]?.type === VpRequestInteractServiceType.mediatedPresentation) {
       this.presentationReview = {
         presentationReviewId: uuidv4(),
         reviewStatus: PresentationReviewStatus.pending
@@ -100,7 +100,7 @@ export class TransactionEntity {
             errors: [],
             vpRequest: {
               challenge: uuidv4(),
-              query: [{ type: VpRequestQueryType.didAuth }],
+              query: [{ type: VpRequestQueryType.didAuth, credentialQuery: [] }],
               interact: this.vpRequest.interact // Just ask the same endpoint again
             }
           },

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
@@ -55,14 +55,7 @@ export class ExchangeService {
       }
     });
 
-    // Persist the exchange
-    const exchange = this.exchangeRepository.create({
-      exchangeId: exchangeDefinitionDto.exchangeId,
-      query: exchangeDefinitionDto.query,
-      interactServiceDefinitions: exchangeDefinitionDto.interactServices,
-      isOneTime: exchangeDefinitionDto.isOneTime,
-      callback: exchangeDefinitionDto.callback
-    });
+    const exchange = new ExchangeEntity(exchangeDefinitionDto);
     await this.exchangeRepository.save(exchange);
     return {
       errors: []
@@ -89,8 +82,6 @@ export class ExchangeService {
     }
     const baseWithControllerPath = `${baseUrl}/vc-api`;
     const transaction = exchange.start(baseWithControllerPath);
-    // TODO: considering saving as a transaction
-    await this.exchangeRepository.save(exchange);
     await this.transactionRepository.save(transaction);
     return {
       errors: [],


### PR DESCRIPTION
This tightens the consistency boundary around the exchange entity.
Exchange entity is no longer mutated as when starting exchange.
So there is no need to save exchange (so no potential need for a db transaction).