### PR TITLE
refactor: move Presention Definition validation to custom validator

### DIFF
--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/custom-validators/presentation-definition-credential-query.validator.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/custom-validators/presentation-definition-credential-query.validator.ts
@@ -1,0 +1,35 @@
+import { IPresentationDefinition, PEX, Status } from '@sphereon/pex';
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator';
+
+/**
+ * https://github.com/typestack/class-validator#custom-validation-decorators
+ */
+export function IsPresentationDefinitionCredentialQuery(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isPresentationDefinitionCredentialQuery',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: validationOptions,
+      validator: {
+        validate(value: IPresentationDefinition, args: ValidationArguments) {
+          const pex = new PEX();
+          const validated = pex.validateDefinition(value);
+          if (Array.isArray(validated)) {
+            validated.forEach((checked) => {
+              if (checked.status === Status.ERROR || checked.status === Status.WARN) {
+                return false;
+              }
+            });
+          } else {
+            if (validated.status === Status.ERROR || validated.status === Status.WARN) {
+              return false;
+            }
+          }
+          return true;
+        }
+      }
+    });
+  };
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/custom-validators/presentation-definition-credential-query.validator.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/custom-validators/presentation-definition-credential-query.validator.ts
@@ -15,19 +15,17 @@ export function IsPresentationDefinitionCredentialQuery(validationOptions?: Vali
       validator: {
         validate(value: IPresentationDefinition, args: ValidationArguments) {
           const pex = new PEX();
-          const validated = pex.validateDefinition(value);
-          if (Array.isArray(validated)) {
-            validated.forEach((checked) => {
-              if (checked.status === Status.ERROR || checked.status === Status.WARN) {
-                return false;
-              }
-            });
-          } else {
-            if (validated.status === Status.ERROR || validated.status === Status.WARN) {
+          try {
+            const validated = pex.validateDefinition(value);
+            const resultArray = Array.isArray(validated) ? validated : [validated];
+            const statuses = resultArray.map((checked) => checked.status);
+            if (statuses.includes(Status.ERROR) || statuses.includes(Status.WARN)) {
               return false;
             }
+            return true;
+          } catch {
+            return false;
           }
-          return true;
         }
       }
     });

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.spec.ts
@@ -1,0 +1,24 @@
+import { validate } from 'class-validator';
+import 'reflect-metadata';
+import { ResidentCardIssuance } from '../../../../test/sample-business-logic/resident-card-issuance.exchange';
+import { ResidentCardPresentation } from '../../../../test/sample-business-logic/resident-card-presentation.exchange';
+
+describe('ExchangeDefinition', () => {
+  describe('Resident Card Presentation', () => {
+    it('should be a valid exchange definition', async () => {
+      const callback = 'https://example.com/endpoint';
+      const exchange = new ResidentCardPresentation(callback);
+      const definition = exchange.getExchangeDefinition();
+      const result = await validate(definition);
+      expect(result).toHaveLength(0);
+    });
+  });
+  describe('Resident Card Issuance', () => {
+    it('should be a valid exchange definition', async () => {
+      const exchange = new ResidentCardIssuance();
+      const definition = exchange.getExchangeDefinition();
+      const result = await validate(definition);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
@@ -1,7 +1,8 @@
-import { IsBoolean, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsNumber, IsString, ValidateNested } from 'class-validator';
 import { VpRequestQueryDto } from './vp-request-query.dto';
 import { ExchangeInteractServiceDefinitionDto } from './exchange-interact-service-definition.dto';
 import { CallbackConfigurationDto } from './callback-configuration.dto';
+import { Type } from 'class-transformer';
 
 /**
  * A exchange definition
@@ -11,14 +12,20 @@ export class ExchangeDefinitionDto {
   exchangeId: string;
 
   @ValidateNested()
+  @IsArray()
+  @Type(() => ExchangeInteractServiceDefinitionDto)
   interactServices: ExchangeInteractServiceDefinitionDto[];
 
   @ValidateNested({ each: true })
+  @IsArray()
+  @Type(() => VpRequestQueryDto)
   query: VpRequestQueryDto[];
 
   @IsBoolean()
   isOneTime: boolean;
 
   @ValidateNested({ each: true })
+  @IsArray()
+  @Type(() => CallbackConfigurationDto)
   callback: CallbackConfigurationDto[];
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-did-auth-query.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-did-auth-query.dto.ts
@@ -1,0 +1,1 @@
+export class VpRequestDidAuthQueryDto {}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-interact.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-interact.dto.ts
@@ -1,4 +1,5 @@
-import { ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, ValidateNested } from 'class-validator';
 import { VpRequestInteractServiceDto } from './vp-request-interact-service.dto';
 
 /**
@@ -6,5 +7,7 @@ import { VpRequestInteractServiceDto } from './vp-request-interact-service.dto';
  */
 export class VpRequestInteractDto {
   @ValidateNested({ each: true })
+  @IsArray()
+  @Type(() => VpRequestInteractServiceDto)
   service: VpRequestInteractServiceDto[];
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.spec.ts
@@ -1,0 +1,29 @@
+import { validate } from 'class-validator';
+import 'reflect-metadata';
+import { VpRequestPresentationDefinitionQueryDto } from './vp-request-presentation-defintion-query.dto';
+
+describe('VpRequestPresentationDefinitionQueryDto', () => {
+  it('should validate valid presentation definition', async () => {
+    const query = new VpRequestPresentationDefinitionQueryDto();
+    query.presentationDefinition = {
+      id: '286bc1e0-f1bd-488a-a873-8d71be3c690e',
+      input_descriptors: [
+        {
+          id: 'my_pres_definition',
+          name: 'My presentation definition'
+        }
+      ]
+    };
+    const result = await validate(query);
+    expect(result).toHaveLength(0);
+  });
+  it('should validate invalid presentation definition', async () => {
+    const query = new VpRequestPresentationDefinitionQueryDto();
+    query.presentationDefinition = {
+      //@ts-expect-error
+      input_descriptors: 10
+    };
+    const result = await validate(query);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.ts
@@ -1,0 +1,7 @@
+import { IPresentationDefinition } from '@sphereon/pex';
+import { IsPresentationDefinitionCredentialQuery } from './custom-validators/presentation-definition-credential-query.validator';
+
+export class VpRequestPresentationDefinitionQueryDto {
+  @IsPresentationDefinitionCredentialQuery()
+  presentationDefinition: IPresentationDefinition;
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
@@ -1,5 +1,8 @@
-import { IsArray, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, IsEnum, ValidateNested } from 'class-validator';
 import { VpRequestQueryType } from '../types/vp-request-query-type';
+import { VpRequestDidAuthQueryDto } from './vp-request-did-auth-query.dto';
+import { VpRequestPresentationDefinitionQueryDto } from './vp-request-presentation-defintion-query.dto';
 
 /**
  * https://w3c-ccg.github.io/vp-request-spec/#query-types
@@ -9,8 +12,18 @@ export class VpRequestQueryDto {
   type: VpRequestQueryType;
 
   /**
-   * TODO: Validate the queries. Maybe with a custom validator E.g. this.#pex.validateDefinition(workflowDefinition.presentationDefinition);
+   * https://github.com/typestack/class-validator/issues/566#issuecomment-605515267
    */
+  @ValidateNested({ each: true })
   @IsArray()
-  credentialQuery: any[];
+  @Type(() => VpRequestPresentationDefinitionQueryDto, {
+    discriminator: {
+      property: 'type',
+      subTypes: [
+        { value: VpRequestPresentationDefinitionQueryDto, name: VpRequestQueryType.presentationDefinition },
+        { value: VpRequestDidAuthQueryDto, name: VpRequestQueryType.didAuth }
+      ]
+    }
+  })
+  credentialQuery: Array<VpRequestPresentationDefinitionQueryDto | VpRequestDidAuthQueryDto>;
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/exchange.entity.ts
@@ -62,7 +62,7 @@ export class ExchangeEntity {
    * Create transaction associated with this exchange.
    *
    * Transactions are created by exchange (exchange is the aggregate root) because the exchange may want to enforce invariants such as
-   * "This exchange may only have a single transaction" (i.e. see isOneTime property)
+   * "This exchange may only have a single transaction" (i.e. see oneTimeTransactionId property)
    *
    * @param baseUrl The baseUrl to use for any interaction services
    * @returns

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
@@ -82,7 +82,7 @@ describe('ExchangeService', () => {
         query: [
           {
             type: VpRequestQueryType.presentationDefinition,
-            credentialQuery: [presentationDefinition]
+            credentialQuery: [{ presentationDefinition }]
           }
         ],
         interactServices: [

--- a/apps/nestjs-wallet/test/app.e2e-spec.ts
+++ b/apps/nestjs-wallet/test/app.e2e-spec.ts
@@ -6,10 +6,10 @@ import { WalletClient } from './wallet-client';
 import { AppModule } from '../src/app.module';
 import { CredentialDto } from '../src/vc-api/credentials/dtos/credential.dto';
 import { IssueOptionsDto } from '../src/vc-api/credentials/dtos/issue-options.dto';
-import { ResidenceCardIssuance } from './sample-business-logic/resident-card-issuance.exchange';
+import { ResidentCardIssuance } from './sample-business-logic/resident-card-issuance.exchange';
 import { VpRequestDto } from 'src/vc-api/exchanges/dtos/vp-request.dto';
 import { ProofPurpose } from '@sphereon/pex';
-import { ResidenceCardPresentation } from './sample-business-logic/resident-card-presentation.exchange';
+import { ResidentCardPresentation } from './sample-business-logic/resident-card-presentation.exchange';
 
 // Increasing timeout for debugging
 // Should only affect this file https://jestjs.io/docs/jest-object#jestsettimeouttimeout
@@ -69,7 +69,7 @@ describe('App (e2e)', () => {
       const vcApiBaseUrl = '/vc-api';
       // Configure credential issuance exchange
       // POST /exchanges
-      const exchange = new ResidenceCardIssuance();
+      const exchange = new ResidentCardIssuance();
       await request(app.getHttpServer())
         .post(`${vcApiBaseUrl}/exchanges`)
         .send(exchange.getExchangeDefinition())
@@ -111,14 +111,12 @@ describe('App (e2e)', () => {
 
       // Configure presentation exchange
       // POST /exchanges
-      const callbackUrlBase = 'http://government-app-backend';
+      const callbackUrlBase = 'http://example.com';
       const callbackUrlPath = '/endpoint';
-      const presentationExchange = new ResidenceCardPresentation(`${callbackUrlBase}${callbackUrlPath}`);
+      const presentationExchange = new ResidentCardPresentation(`${callbackUrlBase}${callbackUrlPath}`);
       const scope = nock(callbackUrlBase).post(callbackUrlPath).reply(201, { message: 'you did it!' });
-      await request(app.getHttpServer())
-        .post(`${vcApiBaseUrl}/exchanges`)
-        .send(presentationExchange.getExchangeDefinition())
-        .expect(201);
+      const exchangeDef = presentationExchange.getExchangeDefinition();
+      await request(app.getHttpServer()).post(`${vcApiBaseUrl}/exchanges`).send(exchangeDef).expect(201);
 
       // Start presentation exchange
       // POST /exchanges/{exchangeId}

--- a/apps/nestjs-wallet/test/sample-business-logic/resident-card-issuance.exchange.ts
+++ b/apps/nestjs-wallet/test/sample-business-logic/resident-card-issuance.exchange.ts
@@ -5,8 +5,9 @@ import { Presentation } from '../../src/vc-api/exchanges/types/presentation';
 import { ExchangeDefinitionDto } from '../../src/vc-api/exchanges/dtos/exchange-definition.dto';
 import { VpRequestInteractServiceType } from '../../src/vc-api/exchanges/types/vp-request-interact-service-type';
 import { VpRequestQueryType } from '../../src/vc-api/exchanges/types/vp-request-query-type';
+import { plainToClass } from 'class-transformer';
 
-export class ResidenceCardIssuance {
+export class ResidentCardIssuance {
   #exchangeId = 'permanent-resident-card-issuance';
   queryType = VpRequestQueryType.didAuth;
 
@@ -31,7 +32,7 @@ export class ResidenceCardIssuance {
       isOneTime: false,
       callback: []
     };
-    return exchangeDefinition;
+    return plainToClass(ExchangeDefinitionDto, exchangeDefinition);
   }
 
   /**

--- a/apps/nestjs-wallet/test/sample-business-logic/resident-card-presentation.exchange.ts
+++ b/apps/nestjs-wallet/test/sample-business-logic/resident-card-presentation.exchange.ts
@@ -1,8 +1,9 @@
+import { plainToClass } from 'class-transformer';
 import { ExchangeDefinitionDto } from '../../src/vc-api/exchanges/dtos/exchange-definition.dto';
 import { VpRequestInteractServiceType } from '../../src/vc-api/exchanges/types/vp-request-interact-service-type';
 import { VpRequestQueryType } from '../../src/vc-api/exchanges/types/vp-request-query-type';
 
-export class ResidenceCardPresentation {
+export class ResidentCardPresentation {
   #exchangeId = `b229a18f-db45-4b33-8d36-25d442467bab`;
   #callbackUrl: string;
   queryType = VpRequestQueryType.presentationDefinition;
@@ -23,14 +24,16 @@ export class ResidenceCardPresentation {
           type: this.queryType,
           credentialQuery: [
             {
-              id: '286bc1e0-f1bd-488a-a873-8d71be3c690e',
-              input_descriptors: [
-                {
-                  id: 'permanent_resident_card',
-                  name: 'Permanent Resident Card',
-                  purpose: 'We can only allow permanent residents into the application'
-                }
-              ]
+              presentationDefinition: {
+                id: '286bc1e0-f1bd-488a-a873-8d71be3c690e',
+                input_descriptors: [
+                  {
+                    id: 'permanent_resident_card',
+                    name: 'Permanent Resident Card',
+                    purpose: 'We can only allow permanent residents into the application'
+                  }
+                ]
+              }
             }
           ]
         }
@@ -47,6 +50,6 @@ export class ResidenceCardPresentation {
         }
       ]
     };
-    return exchangeDefinition;
+    return plainToClass(ExchangeDefinitionDto, exchangeDefinition);
   }
 }


### PR DESCRIPTION
Main changes are:
- Add `IsPresentationDefinitionCredentialQuery` custom validator (which uses `@sphereon/pex`)
- Fix nested validation in `exchange-definition.dto` (needed to add `@Type`)