### PR TITLE
Feat/iva 4/send callback result

### DIFF
--- a/apps/nestjs-wallet/src/vc-api/credentials/credentials.service.ts
+++ b/apps/nestjs-wallet/src/vc-api/credentials/credentials.service.ts
@@ -14,7 +14,7 @@ import { IssueCredentialDto } from './dtos/issue-credential.dto';
 import { VerifiableCredentialDto } from './dtos/verifiable-credential.dto';
 import { VerifiablePresentationDto } from './dtos/verifiable-presentation.dto';
 import { VerifyOptionsDto } from './dtos/verify-options.dto';
-import { VerifyProofResponseDto } from './dtos/verify-proof-response.dto';
+import { VerificationResultDto } from './dtos/verification-result.dto';
 import { AuthenticateDto } from './dtos/authenticate.dto';
 import { ProvePresentationDto } from './dtos/prove-presentation.dto';
 
@@ -60,7 +60,7 @@ export class CredentialsService {
   async verifyCredential(
     vc: VerifiableCredentialDto,
     options: VerifyOptionsDto
-  ): Promise<VerifyProofResponseDto> {
+  ): Promise<VerificationResultDto> {
     const verifyOptions: ISpruceVerifyOptions = options;
     return JSON.parse(await verifyCredential(JSON.stringify(vc), JSON.stringify(verifyOptions)));
   }
@@ -93,7 +93,7 @@ export class CredentialsService {
   async verifyPresentation(
     vp: VerifiablePresentationDto,
     options: VerifyOptionsDto
-  ): Promise<VerifyProofResponseDto> {
+  ): Promise<VerificationResultDto> {
     const verifyOptions: ISpruceVerifyOptions = options;
     return JSON.parse(await verifyPresentation(JSON.stringify(vp), JSON.stringify(verifyOptions)));
   }

--- a/apps/nestjs-wallet/src/vc-api/credentials/dtos/verification-result.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/credentials/dtos/verification-result.dto.ts
@@ -4,7 +4,7 @@ import { IsString, IsArray } from 'class-validator';
  * A response object from verification of a credential or a presentation.
  * https://w3c-ccg.github.io/vc-api/verifier.html
  */
-export class VerifyProofResponseDto {
+export class VerificationResultDto {
   /**
    * The checks performed
    */

--- a/apps/nestjs-wallet/src/vc-api/credentials/types/verification-result.ts
+++ b/apps/nestjs-wallet/src/vc-api/credentials/types/verification-result.ts
@@ -1,29 +1,22 @@
 import { IsString, IsArray } from 'class-validator';
-import { VerificationResult } from '../types/verification-result';
 
 /**
  * A response object from verification of a credential or a presentation.
  * https://w3c-ccg.github.io/vc-api/verifier.html
  */
-export class VerificationResultDto implements VerificationResult {
+export interface VerificationResult {
   /**
    * The checks performed
    */
-  @IsArray()
-  @IsString({ each: true })
   checks: string[];
 
   /**
    * Warnings
    */
-  @IsArray()
-  @IsString({ each: true })
   warnings: string[];
 
   /**
    * Errors
    */
-  @IsArray()
-  @IsString({ each: true })
   errors: string[];
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/presentation-submission.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/presentation-submission.dto.ts
@@ -1,7 +1,7 @@
-import { Column } from 'typeorm';
 import { VerificationResultDto } from '../../credentials/dtos/verification-result.dto';
 import { ValidateNested } from 'class-validator';
 import { VerifiablePresentationDto } from '../../credentials/dtos/verifiable-presentation.dto';
+import { Type } from 'class-transformer';
 
 /**
  * Presentation Submission Dto.
@@ -11,11 +11,13 @@ export class PresentationSubmissionDto {
    * The result of the verification of the submitted VP
    */
   @ValidateNested()
+  @Type(() => VerificationResultDto)
   verificationResult: VerificationResultDto;
 
   /**
    * The Verifiable Presentation submitted in response to the transaction's VP Request
    */
   @ValidateNested()
+  @Type(() => VerifiablePresentationDto)
   vp: VerifiablePresentationDto;
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/presentation-submission.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/presentation-submission.dto.ts
@@ -1,0 +1,21 @@
+import { Column } from 'typeorm';
+import { VerificationResultDto } from '../../credentials/dtos/verification-result.dto';
+import { ValidateNested } from 'class-validator';
+import { VerifiablePresentationDto } from '../../credentials/dtos/verifiable-presentation.dto';
+
+/**
+ * Presentation Submission Dto.
+ */
+export class PresentationSubmissionDto {
+  /**
+   * The result of the verification of the submitted VP
+   */
+  @ValidateNested()
+  verificationResult: VerificationResultDto;
+
+  /**
+   * The Verifiable Presentation submitted in response to the transaction's VP Request
+   */
+  @ValidateNested()
+  vp: VerifiablePresentationDto;
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
@@ -1,4 +1,4 @@
-import { classToPlain, plainToClass } from 'class-transformer';
+import { classToPlain, plainToClass, Type } from 'class-transformer';
 import { IsOptional, IsString, ValidateNested } from 'class-validator';
 import { TransactionEntity } from '../entities/transaction.entity';
 import { PresentationSubmissionDto } from './presentation-submission.dto';
@@ -22,6 +22,7 @@ export class TransactionDto {
    * https://w3c-ccg.github.io/vp-request-spec/
    */
   @ValidateNested()
+  @Type(() => VpRequestDto)
   vpRequest: VpRequestDto;
 
   /**
@@ -29,6 +30,7 @@ export class TransactionDto {
    * Is optional because submission may not have occured yet
    */
   @ValidateNested()
+  @Type(() => PresentationSubmissionDto)
   @IsOptional()
   presentationSubmission?: PresentationSubmissionDto;
 

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
@@ -1,10 +1,12 @@
 import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { PresentationSubmissionDto } from './presentation-submission.dto';
 import { VpRequestDto } from './vp-request.dto';
 
 export class TransactionDto {
   /**
    * An id for the transaction
    */
+  @IsString()
   transactionId: string;
 
   /**
@@ -21,8 +23,10 @@ export class TransactionDto {
   vpRequest: VpRequestDto;
 
   /**
-   * The Verifiable Presentation submitted in response to the VP Request
+   * The submission to the VP Request
+   * Is optional because submission may not have occured yet
    */
-  @Column('simple-json', { nullable: true })
-  submittedVP?: VerifiablePresentation;
+  @ValidateNested()
+  @IsOptional()
+  presentationSubmission?: PresentationSubmissionDto;
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { VpRequestDto } from './vp-request.dto';
+
+export class TransactionDto {
+  /**
+   * An id for the transaction
+   */
+  transactionId: string;
+
+  /**
+   * Each transaction is a part of an exchange
+   * https://w3c-ccg.github.io/vc-api/#exchange-examples
+   */
+  @IsString()
+  exchangeId: string;
+
+  /**
+   * https://w3c-ccg.github.io/vp-request-spec/
+   */
+  @ValidateNested()
+  vpRequest: VpRequestDto;
+
+  /**
+   * The Verifiable Presentation submitted in response to the VP Request
+   */
+  @Column('simple-json', { nullable: true })
+  submittedVP?: VerifiablePresentation;
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/dtos/transaction.dto.ts
@@ -1,4 +1,6 @@
+import { classToPlain, plainToClass } from 'class-transformer';
 import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { TransactionEntity } from '../entities/transaction.entity';
 import { PresentationSubmissionDto } from './presentation-submission.dto';
 import { VpRequestDto } from './vp-request.dto';
 
@@ -29,4 +31,10 @@ export class TransactionDto {
   @ValidateNested()
   @IsOptional()
   presentationSubmission?: PresentationSubmissionDto;
+
+  // TODO: make generic so that it can be used in all Dtos
+  static toDto(transaction: TransactionEntity): TransactionDto {
+    const data = classToPlain(transaction);
+    return plainToClass(TransactionEntity, data);
+  }
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
@@ -1,5 +1,5 @@
 import { VerificationResult } from '../../../vc-api/credentials/types/verification-result';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { VerifiablePresentation } from '../types/verifiable-presentation';
 
 /**
@@ -18,6 +18,9 @@ export class PresentationSubmissionEntity {
       errors: []
     };
   }
+
+  @PrimaryGeneratedColumn()
+  id: string;
 
   /**
    * The result of the verification of the submitted VP

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
@@ -1,0 +1,24 @@
+import { VerificationResult } from '../../../vc-api/credentials/types/verification-result';
+import { Column, Entity } from 'typeorm';
+import { VerifiablePresentation } from '../types/verifiable-presentation';
+
+/**
+ * A TypeOrm entity representing a Presentation Submission.
+ * This is a presentation submitted in response to a VP Request https://w3c-ccg.github.io/vp-request-spec/.
+ * Related to a presentation exchange submission (https://identity.foundation/presentation-exchange/#presentation-submission),
+ * in that the submitted VP could contain a presentation_submission.
+ */
+@Entity()
+export class PresentationSubmissionEntity {
+  /**
+   * The result of the verification of the submitted VP
+   */
+  @Column('simple-json')
+  verificationResult: VerificationResult;
+
+  /**
+   * The Verifiable Presentation submitted in response to the transaction's VP Request
+   */
+  @Column('simple-json')
+  submittedVP: VerifiablePresentation;
+}

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/presentation-submission.entity.ts
@@ -10,6 +10,15 @@ import { VerifiablePresentation } from '../types/verifiable-presentation';
  */
 @Entity()
 export class PresentationSubmissionEntity {
+  constructor(vp: VerifiablePresentation) {
+    this.vp = vp;
+    this.verificationResult = {
+      checks: [], // TODO: add correct checks (e.g. proof check from service)
+      warnings: [],
+      errors: []
+    };
+  }
+
   /**
    * The result of the verification of the submitted VP
    */
@@ -20,5 +29,5 @@ export class PresentationSubmissionEntity {
    * The Verifiable Presentation submitted in response to the transaction's VP Request
    */
   @Column('simple-json')
-  submittedVP: VerifiablePresentation;
+  vp: VerifiablePresentation;
 }

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.spec.ts
@@ -46,7 +46,8 @@ describe('TransactionEntity', () => {
       expect(callback[0].url).toEqual(callback_1);
       expect(response.errors).toHaveLength(0);
       expect(response.vpRequest).toBeUndefined();
-      expect(response.vp).toBeUndefined();
+      expect(response.vp).toBeUndefined(); // No issued credentials in the VP
+      expect(transaction.presentationSubmission.vp).toEqual(vp);
     });
   });
 

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -77,12 +77,6 @@ export class TransactionEntity {
   @JoinColumn()
   presentationSubmission: PresentationSubmissionEntity;
 
-  /**
-   * The Verifiable Presentation submitted in response to the VP Request
-   */
-  @Column('simple-json', { nullable: true })
-  submittedVP?: VerifiablePresentation;
-
   @Column('simple-json')
   callback: CallbackConfiguration[];
 
@@ -169,8 +163,8 @@ export class TransactionEntity {
     if (service.type == VpRequestInteractServiceType.mediatedPresentation) {
       if (this.presentationReview.reviewStatus == PresentationReviewStatus.pending) {
         // In this case, this is the first submission to the exchange
-        if (!this.submittedVP) {
-          this.submittedVP = presentation;
+        if (!this.presentationSubmission) {
+          this.presentationSubmission = new PresentationSubmissionEntity(presentation);
         }
         return {
           response: {
@@ -204,6 +198,7 @@ export class TransactionEntity {
       }
     }
     if (service.type == VpRequestInteractServiceType.unmediatedPresentation) {
+      this.presentationSubmission = new PresentationSubmissionEntity(presentation);
       return {
         response: {
           errors: []

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -9,6 +9,7 @@ import { VpRequestQueryType } from '../types/vp-request-query-type';
 import { PresentationReviewEntity } from './presentation-review.entity';
 import { VpRequestEntity } from './vp-request.entity';
 import { CallbackConfiguration } from '../types/callback-configuration';
+import { PresentationSubmissionEntity } from './presentation-submission.entity';
 
 /**
  * A TypeOrm entity representing an exchange transaction
@@ -66,6 +67,15 @@ export class TransactionEntity {
    */
   @Column('text')
   exchangeId: string;
+
+  /**
+   */
+  @OneToOne(() => PresentationSubmissionEntity, {
+    cascade: true,
+    nullable: true
+  })
+  @JoinColumn()
+  presentationSubmission: PresentationSubmissionEntity;
 
   /**
    * The Verifiable Presentation submitted in response to the VP Request

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -56,10 +56,11 @@ export class TransactionEntity {
   /**
    */
   @OneToOne(() => PresentationReviewEntity, {
-    cascade: true
+    cascade: true,
+    nullable: true
   })
   @JoinColumn()
-  presentationReview: PresentationReviewEntity;
+  presentationReview?: PresentationReviewEntity;
 
   /**
    * Each transaction is a part of an exchange execution

--- a/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -61,7 +61,7 @@ export class TransactionEntity {
   presentationReview: PresentationReviewEntity;
 
   /**
-   * Assumes that each transaction is a part of an exchange execution
+   * Each transaction is a part of an exchange execution
    * https://w3c-ccg.github.io/vc-api/#exchange-examples
    */
   @Column('text')

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
@@ -13,6 +13,7 @@ import { TransactionEntity } from './entities/transaction.entity';
 import { VpRequestQueryType } from './types/vp-request-query-type';
 import { PresentationReviewEntity } from './entities/presentation-review.entity';
 import { ConfigService } from '@nestjs/config';
+import { PresentationSubmissionEntity } from './entities/presentation-submission.entity';
 
 const baseUrl = 'https://test-exchange.com';
 
@@ -30,7 +31,8 @@ describe('ExchangeService', () => {
           VpRequestEntity,
           ExchangeEntity,
           TransactionEntity,
-          PresentationReviewEntity
+          PresentationReviewEntity,
+          PresentationSubmissionEntity
         ]),
         HttpModule
       ],

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
@@ -123,7 +123,8 @@ describe('ExchangeService', () => {
   });
 
   describe('continueExchange', () => {
-    it('should send transaction dto if callback is configured', async () => {
+    // TODO: Write after https://github.com/energywebfoundation/ssi/pull/46 as this will make it easier to test
+    it.skip('should send transaction dto if callback is configured', async () => {
       const transactionId = 'test-tx';
       // const exchangeDef: ExchangeDefinitionDto = {
       //   exchangeId: exchangeId,

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.spec.ts
@@ -19,7 +19,7 @@ const baseUrl = 'https://test-exchange.com';
 
 describe('ExchangeService', () => {
   let service: ExchangeService;
-  let vcApiService: CredentialsService;
+  let credentialsService: CredentialsService;
   let exchangeRepository: Repository<ExchangeEntity>;
   let vpRequestRepository: Repository<VpRequestEntity>;
 
@@ -53,7 +53,7 @@ describe('ExchangeService', () => {
       ]
     }).compile();
 
-    vcApiService = module.get<CredentialsService>(CredentialsService);
+    credentialsService = module.get<CredentialsService>(CredentialsService);
     service = module.get<ExchangeService>(ExchangeService);
     exchangeRepository = module.get<Repository<ExchangeEntity>>(getRepositoryToken(ExchangeEntity));
     vpRequestRepository = module.get<Repository<VpRequestEntity>>(getRepositoryToken(VpRequestEntity));
@@ -117,6 +117,36 @@ describe('ExchangeService', () => {
       };
       await service.createExchange(exchangeDef);
       const exchangeResponse = await service.startExchange(exchangeId);
+      expect(exchangeResponse.vpRequest.interact.service).toHaveLength(1);
+      expect(exchangeResponse.vpRequest.interact.service[0].serviceEndpoint).toContain(baseUrl);
+    });
+  });
+
+  describe('continueExchange', () => {
+    it('should send transaction dto if callback is configured', async () => {
+      const transactionId = 'test-tx';
+      // const exchangeDef: ExchangeDefinitionDto = {
+      //   exchangeId: exchangeId,
+      //   interactServices: [
+      //     {
+      //       type: VpRequestInteractServiceType.unmediatedPresentation
+      //     }
+      //   ],
+      //   query: [],
+      //   isOneTime: false,
+      //   callback: []
+      // };
+      const vp = {
+        '@context': [
+          'https://www.w3.org/2018/credentials/v1',
+          'https://www.w3.org/2018/credentials/examples/v1'
+        ],
+        type: ['VerifiablePresentation'],
+        verifiableCredential: [],
+        holder: 'did:key:z6MksBH4LMy8SoYFUNjDXtQ2Rq4dHnyuemowxXqzLpuB6nvc',
+        proof: {}
+      };
+      const exchangeResponse = await service.continueExchange(vp, transactionId);
       expect(exchangeResponse.vpRequest.interact.service).toHaveLength(1);
       expect(exchangeResponse.vpRequest.interact.service[0].serviceEndpoint).toContain(baseUrl);
     });

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
@@ -70,8 +70,7 @@ export class ExchangeService {
    */
   public async continueExchange(
     verifiablePresentation: VerifiablePresentationDto,
-    transactionId: string,
-    exchangeId: string
+    transactionId: string
   ): Promise<ExchangeResponseDto> {
     const transactionQuery = await this.getExchangeTransaction(transactionId);
     if (transactionQuery.errors.length > 0 || !transactionQuery.transaction) {

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
@@ -12,6 +12,7 @@ import { ExchangeDefinitionDto } from './dtos/exchange-definition.dto';
 import { TransactionEntity } from './entities/transaction.entity';
 import { ConfigService } from '@nestjs/config';
 import { VerifyOptionsDto } from '../credentials/dtos/verify-options.dto';
+import { TransactionDto } from './dtos/transaction.dto';
 
 @Injectable()
 export class ExchangeService {
@@ -95,7 +96,9 @@ export class ExchangeService {
     await this.transactionRepository.save(transaction);
     callback?.forEach((callback) => {
       try {
-        this.httpService.post(callback.url, response).subscribe({
+        // TODO: check if toDto is working. Seems be keeping it as Entity type.
+        const body = TransactionDto.toDto(transaction);
+        this.httpService.post(callback.url, body).subscribe({
           // next: (v) => console.log(v),
           // complete: console.info,
           // error: console.error

--- a/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/nestjs-wallet/src/vc-api/exchanges/exchange.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ProofPurpose } from '@sphereon/pex';
@@ -95,17 +95,12 @@ export class ExchangeService {
     const { response, callback } = transaction.processPresentation(verifiablePresentation);
     await this.transactionRepository.save(transaction);
     callback?.forEach((callback) => {
-      try {
-        // TODO: check if toDto is working. Seems be keeping it as Entity type.
-        const body = TransactionDto.toDto(transaction);
-        this.httpService.post(callback.url, body).subscribe({
-          // next: (v) => console.log(v),
-          // complete: console.info,
-          // error: console.error
-        });
-      } catch {
-        // TODO: log exception
-      }
+      // TODO: check if toDto is working. Seems be keeping it as Entity type.
+      const body = TransactionDto.toDto(transaction);
+      this.httpService.post(callback.url, body).subscribe({
+        next: (v) => Logger.log(v),
+        error: Logger.error
+      });
     });
     return response;
   }

--- a/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
+++ b/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
@@ -111,7 +111,7 @@ export class VcApiController {
    * @param transactionId id of the exchange transaction
    * @returns
    */
-  @Get('/exchanges/:exchangeId/transactions/:transactionId')
+  @Get('/exchanges/:exchangeId/:transactionId')
   async getTransaction(
     @Param('exchangeId') exchangeId: string,
     @Param('transactionId') transactionId: string
@@ -124,13 +124,13 @@ export class VcApiController {
    * A NON-STANDARD endpoint currently.
    * Similar to https://github.com/energywebfoundation/ssi-hub/blob/8b860e7cdae4e1b1aa75afeab8b9df7ab26befbb/src/modules/claim/claim.controller.ts#L80
    *
-   * TODO: Perhaps reviews are not separate from transactions? Perhaps one updated the transaction directly
+   * TODO: Perhaps reviews are not separate from transactions? Perhaps one updates the transaction directly
    * TODO: Needs to have special authorization
    * @param exchangeId id of the exchange
    * @param transactionId id of the exchange transaction
    * @returns
    */
-  @Put('/exchanges/reviews/:transactionId')
+  @Put('/exchanges/:exchangeId/:transactionId/review')
   async getExchangeTransaction(@Param('transactionId') transactionId: string) {
     return new NotImplementedException();
   }

--- a/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
+++ b/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
@@ -98,7 +98,7 @@ export class VcApiController {
     @Param('transactionId') transactionId: string,
     @Body() presentation: VerifiablePresentationDto
   ): Promise<ExchangeResponseDto> {
-    return await this.exchangeService.continueExchange(presentation, transactionId, exchangeId);
+    return await this.exchangeService.continueExchange(presentation, transactionId);
   }
 
   /**

--- a/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
+++ b/apps/nestjs-wallet/src/vc-api/vc-api.controller.ts
@@ -102,7 +102,7 @@ export class VcApiController {
   }
 
   /**
-   * Get exchange transactions that require reviews
+   * Get exchange transaction by id
    * A NON-STANDARD endpoint currently.
    * Similar to https://identitycache.energyweb.org/api/#/Claims/ClaimController_getByIssuerDid
    *
@@ -111,8 +111,11 @@ export class VcApiController {
    * @param transactionId id of the exchange transaction
    * @returns
    */
-  @Get('/exchanges/reviews')
-  async getExchangeReviews(@Param('transactionId') transactionId: string) {
+  @Get('/exchanges/:exchangeId/transactions/:transactionId')
+  async getTransaction(
+    @Param('exchangeId') exchangeId: string,
+    @Param('transactionId') transactionId: string
+  ) {
     return new NotImplementedException();
   }
 

--- a/apps/nestjs-wallet/src/vc-api/vc-api.module.ts
+++ b/apps/nestjs-wallet/src/vc-api/vc-api.module.ts
@@ -11,12 +11,19 @@ import { ExchangeEntity } from './exchanges/entities/exchange.entity';
 import { VpRequestEntity } from './exchanges/entities/vp-request.entity';
 import { TransactionEntity } from './exchanges/entities/transaction.entity';
 import { PresentationReviewEntity } from './exchanges/entities/presentation-review.entity';
+import { PresentationSubmissionEntity } from './exchanges/entities/presentation-submission.entity';
 
 @Module({
   imports: [
     DidModule,
     KeyModule,
-    TypeOrmModule.forFeature([VpRequestEntity, ExchangeEntity, TransactionEntity, PresentationReviewEntity]),
+    TypeOrmModule.forFeature([
+      VpRequestEntity,
+      ExchangeEntity,
+      TransactionEntity,
+      PresentationReviewEntity,
+      PresentationSubmissionEntity
+    ]),
     ConfigModule,
     HttpModule
   ],

--- a/apps/nestjs-wallet/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/nestjs-wallet/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -20,11 +20,6 @@ export const rebeamExchangeSuite = () => {
     const callbackUrlBase = 'http://example.com';
     const callbackUrlPath = '/endpoint';
     const presentationExchange = new RebeamCpoNode(`${callbackUrlBase}${callbackUrlPath}`);
-    // const expectedResponseBody = {
-    //   exchangeId: presentationExchange.getExchangeId(),
-    //   submittedVps: [],
-    //   result:
-    // }
     const scope = nock(callbackUrlBase).post(callbackUrlPath).reply(201);
     const exchangeDef = presentationExchange.getExchangeDefinition();
     await request(app.getHttpServer()).post(`${vcApiBaseUrl}/exchanges`).send(exchangeDef).expect(201);

--- a/apps/nestjs-wallet/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/nestjs-wallet/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -20,6 +20,11 @@ export const rebeamExchangeSuite = () => {
     const callbackUrlBase = 'http://example.com';
     const callbackUrlPath = '/endpoint';
     const presentationExchange = new RebeamCpoNode(`${callbackUrlBase}${callbackUrlPath}`);
+    // const expectedResponseBody = {
+    //   exchangeId: presentationExchange.getExchangeId(),
+    //   submittedVps: [],
+    //   result:
+    // }
     const scope = nock(callbackUrlBase).post(callbackUrlPath).reply(201);
     const exchangeDef = presentationExchange.getExchangeDefinition();
     await request(app.getHttpServer()).post(`${vcApiBaseUrl}/exchanges`).send(exchangeDef).expect(201);


### PR DESCRIPTION
There is currently this callback feature so that verifiers can be notified when their configured exchange is done. Instead of sending in the callback the `ExchangeResponse` that is sent the holder/presenter, sending a `TransactionDto` as this has more detailed information for the verifier.

TODO:
- [x] Initial implement
- [x] check response in e2e tests -> Not possible to check response contents in `nock`