### PR TITLE
feat(vc-api): add getTransaction endpoint

### DIFF
--- a/apps/vc-api/src/vc-api/exchanges/dtos/get-transaction.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/get-transaction.dto.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021, 2022 Energy Web Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Type } from 'class-transformer';
+import { IsArray, IsString, ValidateNested } from 'class-validator';
+import { TransactionDto } from './transaction.dto';
+
+/**
+ * Response to a GET Transaction query
+ */
+export class GetTransactionDto {
+  /**
+   * Any errors encountered querying transaction
+   */
+  @IsArray()
+  @IsString({ each: true })
+  errors: string[];
+
+  /**
+   * The returned transaction
+   */
+  @ValidateNested()
+  @Type(() => TransactionDto)
+  transaction: TransactionDto;
+}

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -26,6 +26,8 @@ import { ExchangeService } from './exchanges/exchange.service';
 import { ExchangeResponseDto } from './exchanges/dtos/exchange-response.dto';
 import { ExchangeDefinitionDto } from './exchanges/dtos/exchange-definition.dto';
 import { ProvePresentationDto } from './credentials/dtos/prove-presentation.dto';
+import { GetTransactionDto } from './exchanges/dtos/get-transaction.dto';
+import { TransactionDto } from './exchanges/dtos/transaction.dto';
 
 /**
  * VcApi API conforms to W3C vc-api
@@ -133,6 +135,11 @@ export class VcApiController {
     @Param('exchangeId') exchangeId: string,
     @Param('transactionId') transactionId: string
   ) {
-    return new NotImplementedException();
+    const queryResult = await this.exchangeService.getExchangeTransaction(transactionId);
+    const response: GetTransactionDto = {
+      errors: queryResult.errors,
+      transaction: queryResult.transaction ? TransactionDto.toDto(queryResult.transaction) : undefined
+    };
+    return response;
   }
 }

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -136,9 +136,12 @@ export class VcApiController {
     @Param('transactionId') transactionId: string
   ) {
     const queryResult = await this.exchangeService.getExchangeTransaction(transactionId);
+    const transactionDto = queryResult.transaction
+      ? TransactionDto.toDto(queryResult.transaction)
+      : undefined;
     const response: GetTransactionDto = {
       errors: queryResult.errors,
-      transaction: queryResult.transaction ? TransactionDto.toDto(queryResult.transaction) : undefined
+      transaction: transactionDto
     };
     return response;
   }

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -60,7 +60,8 @@ export const residentCardExchangeSuite = () => {
     await walletClient.continueExchange(issuanceExchangeContinuationEndpoint, didAuthVp, true);
 
     // As the issuer, get the transaction
-    const transactionId = issuanceExchangeContinuationEndpoint.split('/').at(-1);
+    const urlComponents = issuanceExchangeContinuationEndpoint.split('/');
+    const transactionId = urlComponents[urlComponents.length - 1];
     const transaction = await walletClient.getExchangeTransaction(exchange.getExchangeId(), transactionId);
 
     // TODO: have the issuer get the review and approve. For now, just issue directly

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -33,14 +33,14 @@ export const residentCardExchangeSuite = () => {
       .send(exchange.getExchangeDefinition())
       .expect(201);
 
-    // Start issuance exchange
+    // As holder, start issuance exchange
     // POST /exchanges/{exchangeId}
     const issuanceExchangeEndpoint = `${vcApiBaseUrl}/exchanges/${exchange.getExchangeId()}`;
     const issuanceVpRequest = await walletClient.startExchange(issuanceExchangeEndpoint, exchange.queryType);
     const issuanceExchangeContinuationEndpoint = getContinuationEndpoint(issuanceVpRequest);
     expect(issuanceExchangeContinuationEndpoint).toContain(issuanceExchangeEndpoint);
 
-    // Create new DID and presentation to authentication as this DID
+    // As holder, create new DID and presentation to authentication as this DID
     // DID auth presentation: https://github.com/spruceid/didkit/blob/c5c422f2469c2c5cc2f6e6d8746e95b552fce3ed/lib/web/src/lib.rs#L382
     const holderDID = await walletClient.createDID('key');
     const holderVerificationMethod = holderDID.verificationMethod[0].id;
@@ -56,8 +56,12 @@ export const residentCardExchangeSuite = () => {
     const didAuthVp = didAuthResponse.body;
     expect(didAuthVp).toBeDefined();
 
-    // Continue exchange by submitting presention
+    // As holder, continue exchange by submitting did auth presention
     await walletClient.continueExchange(issuanceExchangeContinuationEndpoint, didAuthVp, true);
+
+    // As the issuer, get the transaction
+    const transactionId = issuanceExchangeContinuationEndpoint.split('/').at(-1);
+    const transaction = await walletClient.getExchangeTransaction(exchange.getExchangeId(), transactionId);
 
     // TODO: have the issuer get the review and approve. For now, just issue directly
     const issueResult = await exchange.issueCredential(didAuthVp, walletClient);

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -61,7 +61,7 @@ export const residentCardExchangeSuite = () => {
 
     // As the issuer, get the transaction
     const urlComponents = issuanceExchangeContinuationEndpoint.split('/');
-    const transactionId = urlComponents[urlComponents.length - 1];
+    const transactionId = urlComponents.pop();
     const transaction = await walletClient.getExchangeTransaction(exchange.getExchangeId(), transactionId);
 
     // TODO: have the issuer get the review and approve. For now, just issue directly

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -24,7 +24,8 @@ import { ProvePresentationDto } from '../src/vc-api/credentials/dtos/prove-prese
 import { VerifiablePresentationDto } from '../src/vc-api/credentials/dtos/verifiable-presentation.dto';
 import { VpRequestDto } from '../src/vc-api/exchanges/dtos/vp-request.dto';
 import { ExchangeResponseDto } from '../src/vc-api/exchanges/dtos/exchange-response.dto';
-import { VpRequestQueryType } from 'src/vc-api/exchanges/types/vp-request-query-type';
+import { VpRequestQueryType } from '../src/vc-api/exchanges/types/vp-request-query-type';
+import { TransactionDto } from '../src/vc-api/exchanges/dtos/transaction.dto';
 
 /**
  * A wallet client for e2e tests
@@ -106,5 +107,17 @@ export class WalletClient {
     if (expectsVpRequest) {
       expect(continueExchangeResponse.body.vpRequest).toBeDefined();
     }
+  }
+
+  /**
+   * GET /exchanges/{exchangeId}/{transactionId}
+   */
+  async getExchangeTransaction(exchangeId: string, transactionId: string) {
+    const continueExchangeResponse = await request(this.#app.getHttpServer())
+      .get(`/vc-api/exchanges/${exchangeId}/${transactionId}`)
+      .expect(200);
+    expect(continueExchangeResponse.body.errors).toHaveLength(0);
+    expect(continueExchangeResponse.body.transaction).toBeDefined();
+    return continueExchangeResponse.body.transaction as TransactionDto;
   }
 }


### PR DESCRIPTION
This adds a (non-standard, not included in https://w3c-ccg.github.io/vc-api/) endpoint to allow for querying of an exchange transaction. 

I'm basing my notion of "exchange transactions" from the continue exchange endpoint of vc-api https://w3c-ccg.github.io/vc-api/#continue-exchange

This endpoint is needed for the "query outstanding presentations to review" step of a mediated exchange https://github.com/energywebfoundation/ssi#credential-presentationissuance