### PR TITLE
removing verification method

### DIFF
--- a/apps/vc-api/src/did/did.service.ts
+++ b/apps/vc-api/src/did/did.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DIDEthrFactory, DIDKeyFactory } from '@energyweb/ssi-did';
+import { DIDEthrFactory, DIDKeyFactory, DifJsonWebKey } from '@energyweb/ssi-did';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DIDDocument, VerificationMethod } from 'did-resolver';

--- a/apps/vc-api/src/did/did.service.ts
+++ b/apps/vc-api/src/did/did.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DIDEthrFactory, DIDKeyFactory, DifJsonWebKey } from '@energyweb/ssi-did';
+import { DIDEthrFactory, DIDKeyFactory } from '@energyweb/ssi-did';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DIDDocument, VerificationMethod } from 'did-resolver';

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
@@ -95,7 +95,6 @@ describe('CredentialsService', () => {
        * Delete jws from proof as it is not deterministic
        * TODO: confirm this from the Ed25519Signature2018 spec
        */
-      console.log(vc.proof);
       delete vc.proof.jws;
       const expectedVcCopy = JSON.parse(JSON.stringify(expectedVc));
       delete expectedVcCopy.proof.jws;
@@ -107,6 +106,7 @@ describe('CredentialsService', () => {
     const issueOptions: IssueOptionsDto = {
       created: '2021-11-16T14:52:19.514Z'
     };
+    jest.spyOn(didService, 'getDID').mockResolvedValue(didDoc);
     jest.spyOn(didService, 'getVerificationMethod').mockResolvedValue({
       id: verificationMethod,
       type: 'some-verification-method-type',
@@ -116,7 +116,6 @@ describe('CredentialsService', () => {
         kty: 'OKP'
       }
     });
-
     jest.spyOn(keyService, 'getPrivateKeyFromKeyId').mockResolvedValue(key);
     const vc1 = await service.issueCredential({
       credential: energyContractCredential,

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
@@ -29,7 +29,7 @@ import {
   energyContractCredential,
   chargingDataVerifiableCredential,
   energyContractVerifiableCredential,
-  chargingDataCredential,
+  getChargingDataCredential,
   presentationDefinition,
   rebeamVerifiablePresentation,
   rebeamPresentation
@@ -79,7 +79,7 @@ describe('CredentialsService', () => {
 
   it.each([
     [energyContractCredential, energyContractVerifiableCredential],
-    [chargingDataCredential, chargingDataVerifiableCredential]
+    [getChargingDataCredential(did), chargingDataVerifiableCredential]
   ])(
     'credential %p can be issued to be a vc %p',
     async (credential: CredentialDto, expectedVc: VerifiableCredential) => {
@@ -122,7 +122,7 @@ describe('CredentialsService', () => {
       options: issueOptions
     });
     const vc2 = await service.issueCredential({
-      credential: chargingDataCredential,
+      credential: getChargingDataCredential(did),
       options: issueOptions
     });
     const presentation = service.presentationFrom(presentationDefinition as IPresentationDefinition, [

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.spec.ts
@@ -84,7 +84,6 @@ describe('CredentialsService', () => {
     'credential %p can be issued to be a vc %p',
     async (credential: CredentialDto, expectedVc: VerifiableCredential) => {
       const issuanceOptions: IssueOptionsDto = {
-        proofPurpose: ProofPurpose.assertionMethod,
         created: '2021-11-16T14:52:19.514Z'
       };
       jest.spyOn(didService, 'getDID').mockResolvedValueOnce(didDoc);
@@ -146,18 +145,16 @@ describe('CredentialsService', () => {
   });
 
   it('should prove a vp', async () => {
-    const issuanceOptions: IssueOptionsDto = {
+    const presentationOptions: ProvePresentationOptionsDto = {
+      verificationMethod: didDoc.verificationMethod[0].id,
       proofPurpose: ProofPurpose.authentication,
       created: rebeamVerifiablePresentation.proof.created
     };
     jest.spyOn(didService, 'getDID').mockResolvedValueOnce(didDoc);
     jest.spyOn(didService, 'getVerificationMethod').mockResolvedValueOnce(didDoc.verificationMethod[0]);
     jest.spyOn(keyService, 'getPrivateKeyFromKeyId').mockResolvedValueOnce(key);
-    const vp = await service.provePresentation({
-      presentation: rebeamPresentation,
-      options: issuanceOptions
-    });
-    expect(energyContractVerifiableCredential['proof']['jws']).toBeDefined();
+    const vp = await service.provePresentation({ presentation, options: presentationOptions });
+    expect(vc['proof']['jws']).toBeDefined();
     /**
      * Delete jws from proof as it is not deterministic
      * TODO: confirm this from the Ed25519Signature2018 spec
@@ -186,7 +183,9 @@ describe('CredentialsService', () => {
   });
 
   it('should be able to generate DIDAuth', async () => {
-    const issuanceOptions: IssueOptionsDto = {
+    const challenge = '2679f7f3-d9ff-4a7e-945c-0f30fb0765bd';
+    const issuanceOptions: ProvePresentationOptionsDto = {
+      verificationMethod: didDoc.verificationMethod[0].id,
       proofPurpose: ProofPurpose.authentication,
       created: '2021-11-16T14:52:19.514Z',
       challenge

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -39,6 +39,8 @@ import { PresentationDto } from './dtos/presentation.dto';
 import { IPresentationDefinition, IVerifiableCredential, PEX, Status } from '@sphereon/pex';
 import { VerificationMethod } from 'did-resolver';
 import { ProofPurpose } from '@sphereon/pex';
+import { PresentationDefinitionWrapper } from '@sphereon/pex-models';
+import { ProvePresentationOptionsDto } from './dtos/prove-presentation-options.dto';
 
 /**
  * Credential issuance options that Spruce accepts
@@ -133,10 +135,7 @@ export class CredentialsService implements CredentialVerifier {
       provePresentationDto.presentation.holder
     );
     const key = await this.getKeyForVerificationMethod(verificationMethod.id);
-    const proofOptions = this.mapVcApiIssueOptionsToSpruceIssueOptions(
-      provePresentationDto.options,
-      verificationMethod.id
-    );
+    const proofOptions = this.mapVcApiPresentationOptionsToSpruceIssueOptions(provePresentationDto.options);
     return JSON.parse(
       await issuePresentation(
         JSON.stringify(provePresentationDto.presentation),
@@ -156,10 +155,7 @@ export class CredentialsService implements CredentialVerifier {
     }
     const verificationMethod = await this.getVerificationMethodForDid(authenticateDto.did);
     const key = await this.getKeyForVerificationMethod(verificationMethod.id);
-    const proofOptions = this.mapVcApiIssueOptionsToSpruceIssueOptions(
-      authenticateDto.options,
-      verificationMethod.id
-    );
+    const proofOptions = this.mapVcApiPresentationOptionsToSpruceIssueOptions(authenticateDto.options);
     return JSON.parse(await DIDAuth(authenticateDto.did, JSON.stringify(proofOptions), JSON.stringify(key)));
   }
 
@@ -200,7 +196,7 @@ export class CredentialsService implements CredentialVerifier {
   }
 
   /**
-   * As the Spruce proof issuance options may not align perfectly with the VC-API spec,
+   * As the Spruce proof issuance options may not align perfectly with the VC-API spec issuanceOptions,
    * this method provides a translation between the two
    * @param options
    * @returns
@@ -212,6 +208,23 @@ export class CredentialsService implements CredentialVerifier {
     return {
       proofPurpose: ProofPurpose.assertionMethod, // Issuance is always an "assertion" proof, AFAIK
       verificationMethod: verificationMethodId,
+      created: options.created,
+      challenge: options.challenge
+    };
+  }
+
+  /**
+   * As the Spruce proof issuance options may not align perfectly with the VC-API spec provePresentationOptions,
+   * this method provides a translation between the two
+   * @param options
+   * @returns
+   */
+  private mapVcApiPresentationOptionsToSpruceIssueOptions(
+    options: ProvePresentationOptionsDto
+  ): ISpruceIssueOptions {
+    return {
+      proofPurpose: options.proofPurpose,
+      verificationMethod: options.verificationMethod,
       created: options.created,
       challenge: options.challenge
     };

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -131,10 +131,10 @@ export class CredentialsService implements CredentialVerifier {
   }
 
   async provePresentation(provePresentationDto: ProvePresentationDto): Promise<VerifiablePresentationDto> {
-    const verificationMethod = await this.getVerificationMethodForDid(
-      provePresentationDto.presentation.holder
-    );
-    const key = await this.getKeyForVerificationMethod(verificationMethod.id);
+    const verificationMethodId =
+      provePresentationDto.options.verificationMethod ??
+      (await this.getVerificationMethodForDid(provePresentationDto.presentation.holder)).id;
+    const key = await this.getKeyForVerificationMethod(verificationMethodId);
     const proofOptions = this.mapVcApiPresentationOptionsToSpruceIssueOptions(provePresentationDto.options);
     return JSON.parse(
       await issuePresentation(
@@ -153,8 +153,10 @@ export class CredentialsService implements CredentialVerifier {
     if (authenticateDto.options.proofPurpose !== ProofPurpose.authentication) {
       throw new Error('proof purpose must be authentication for DIDAuth');
     }
-    const verificationMethod = await this.getVerificationMethodForDid(authenticateDto.did);
-    const key = await this.getKeyForVerificationMethod(verificationMethod.id);
+    const verificationMethodId =
+      authenticateDto.options.verificationMethod ??
+      (await this.getVerificationMethodForDid(authenticateDto.did)).id;
+    const key = await this.getKeyForVerificationMethod(verificationMethodId);
     const proofOptions = this.mapVcApiPresentationOptionsToSpruceIssueOptions(authenticateDto.options);
     return JSON.parse(await DIDAuth(authenticateDto.did, JSON.stringify(proofOptions), JSON.stringify(key)));
   }

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -38,6 +38,7 @@ import { CredentialVerifier } from './types/credential-verifier';
 import { PresentationDto } from './dtos/presentation.dto';
 import { IPresentationDefinition, IVerifiableCredential, PEX, Status } from '@sphereon/pex';
 import { VerificationMethod } from 'did-resolver';
+import { ProofPurpose } from '@sphereon/pex';
 
 /**
  * Credential issuance options that Spruce accepts
@@ -150,7 +151,7 @@ export class CredentialsService implements CredentialVerifier {
    * https://w3c-ccg.github.io/vp-request-spec/#did-authentication-request
    */
   async didAuthenticate(authenticateDto: AuthenticateDto): Promise<VerifiablePresentationDto> {
-    if (authenticateDto.options.proofPurpose !== 'authentication') {
+    if (authenticateDto.options.proofPurpose !== ProofPurpose.authentication) {
       throw new Error('proof purpose must be authentication for DIDAuth');
     }
     const verificationMethod = await this.getVerificationMethodForDid(authenticateDto.did);
@@ -209,7 +210,7 @@ export class CredentialsService implements CredentialVerifier {
     verificationMethodId: string
   ): ISpruceIssueOptions {
     return {
-      proofPurpose: options.proofPurpose,
+      proofPurpose: ProofPurpose.assertionMethod, // Issuance is always an "assertion" proof, AFAIK
       verificationMethod: verificationMethodId,
       created: options.created,
       challenge: options.challenge

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -216,7 +216,7 @@ export class CredentialsService implements CredentialVerifier {
   }
 
   /**
-   * As the Spruce proof issuance options may not align perfectly with the VC-API spec provePresentationOptions,
+   * As the Spruce proof presentation options may not align perfectly with the VC-API spec provePresentationOptions,
    * this method provides a translation between the two
    * @param options
    * @returns

--- a/apps/vc-api/src/vc-api/credentials/dtos/authenticate.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/authenticate.dto.ts
@@ -16,7 +16,7 @@
  */
 
 import { IsString, ValidateNested } from 'class-validator';
-import { IssueOptionsDto } from './issue-options.dto';
+import { ProvePresentationOptionsDto } from './prove-presentation-options.dto';
 
 /**
  * DTO which contains DID holder to authenticate and options
@@ -26,5 +26,5 @@ export class AuthenticateDto {
   did: string;
 
   @ValidateNested()
-  options: IssueOptionsDto;
+  options: ProvePresentationOptionsDto;
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/issue-options.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issue-options.dto.ts
@@ -31,12 +31,6 @@ export class IssueOptionsDto {
   type?: string;
 
   /**
-   * The URI of the verificationMethod used for the proof. Default assertionMethod URI.
-   */
-  @IsString()
-  verificationMethod: string;
-
-  /**
    * The purpose of the proof. Default 'assertionMethod'.
    */
   @IsString()

--- a/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation-options.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation-options.dto.ts
@@ -19,10 +19,30 @@ import { ProofPurpose } from '@sphereon/pex';
 import { IsString, IsObject, IsOptional } from 'class-validator';
 
 /**
- * Options for specifying how the Data Integrity Proof is created for a credential issuance
- * https://w3c-ccg.github.io/vc-api/issuer.html#operation/issueCredential
+ * Options for specifying how the Data Integrity Proof is created for a credential presentation proof
+ * https://w3c-ccg.github.io/vc-api/#prove-presentation
  */
-export class IssueOptionsDto {
+export class ProvePresentationOptionsDto {
+  /**
+   * The type of the proof. Default is an appropriate proof type corresponding to the verification method.
+   */
+  @IsString()
+  @IsOptional()
+  type?: string;
+
+  /**
+   * The URI of the verificationMethod used for the proof. Default assertionMethod URI.
+   */
+  @IsString()
+  verificationMethod: string;
+
+  /**
+   * The purpose of the proof. Default 'assertionMethod'.
+   */
+  @IsString()
+  @IsOptional()
+  proofPurpose?: ProofPurpose;
+
   /**
    * The date and time of the proof (with a maximum accuracy in seconds). Default current system time.
    */

--- a/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation.dto.ts
@@ -16,8 +16,8 @@
  */
 
 import { ValidateNested } from 'class-validator';
-import { IssueOptionsDto } from './issue-options.dto';
 import { PresentationDto } from './presentation.dto';
+import { ProvePresentationOptionsDto } from './prove-presentation-options.dto';
 
 /**
  * DTO which contains presentation and options
@@ -27,5 +27,5 @@ export class ProvePresentationDto {
   presentation: PresentationDto;
 
   @ValidateNested()
-  options: IssueOptionsDto;
+  options: ProvePresentationOptionsDto;
 }

--- a/apps/vc-api/test/vc-api/credential.service.spec.data.ts
+++ b/apps/vc-api/test/vc-api/credential.service.spec.data.ts
@@ -1,4 +1,3 @@
-import { IPresentation } from '@sphereon/pex';
 import { Optionality, Rules } from '@sphereon/pex-models';
 import { CredentialDto } from 'src/vc-api/credentials/dtos/credential.dto';
 import { Presentation } from 'src/vc-api/exchanges/types/presentation';
@@ -116,32 +115,34 @@ export const energyContractCredential: CredentialDto = {
   issuanceDate: '2022-03-18T08:57:32.477Z'
 };
 
-export const chargingDataCredential: CredentialDto = {
-  '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    {
-      timestamp: 'ew:timestamp',
-      kwh: 'ew:kwh',
-      chargingData: { '@id': 'ew:chargingData', '@type': 'ew:chargingData' },
-      ChargingData: 'ew:ChargingData',
-      contractDID: 'ew:contractDID',
-      evseId: 'ew:evseId',
-      ew: 'https://energyweb.org/ld-context-2022#'
-    }
-  ],
-  id: 'urn:uuid:a6032135-75d6-4019-b59d-420168c7cd85',
-  type: ['VerifiableCredential', 'ChargingData'],
-  credentialSubject: {
-    id: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
-    chargingData: {
-      contractDID: 'did:ethr:blxm-local:0x429eCb49aAC34E076f19D5C91d7e8B956AEf9c08',
-      evseId: '123',
-      kwh: '5',
-      timestamp: '2022-04-05T15:45:35.346Z'
-    }
-  },
-  issuer: did,
-  issuanceDate: '2022-03-18T08:57:32.477Z'
+export const getChargingDataCredential: (issuerDid: string) => CredentialDto = (issuerDid) => {
+  return {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      {
+        timestamp: 'ew:timestamp',
+        kwh: 'ew:kwh',
+        chargingData: { '@id': 'ew:chargingData', '@type': 'ew:chargingData' },
+        ChargingData: 'ew:ChargingData',
+        contractDID: 'ew:contractDID',
+        evseId: 'ew:evseId',
+        ew: 'https://energyweb.org/ld-context-2022#'
+      }
+    ],
+    id: 'urn:uuid:a6032135-75d6-4019-b59d-420168c7cd85',
+    type: ['VerifiableCredential', 'ChargingData'],
+    credentialSubject: {
+      id: issuerDid,
+      chargingData: {
+        contractDID: 'did:ethr:blxm-local:0x429eCb49aAC34E076f19D5C91d7e8B956AEf9c08',
+        evseId: '123',
+        kwh: '5',
+        timestamp: '2022-04-05T15:45:35.346Z'
+      }
+    },
+    issuer: issuerDid,
+    issuanceDate: '2022-03-18T08:57:32.477Z'
+  };
 };
 
 export const energyContractVerifiableCredential: VerifiableCredential = {
@@ -157,7 +158,7 @@ export const energyContractVerifiableCredential: VerifiableCredential = {
 };
 
 export const chargingDataVerifiableCredential: VerifiableCredential = {
-  ...chargingDataCredential,
+  ...getChargingDataCredential(did),
   proof: {
     type: 'Ed25519Signature2018',
     proofPurpose: 'assertionMethod',
@@ -202,10 +203,7 @@ export const rebeamPresentation: Presentation = {
       }
     ]
   },
-  verifiableCredential: [
-    energyContractVerifiableCredential,
-    chargingDataVerifiableCredential
-  ]
+  verifiableCredential: [energyContractVerifiableCredential, chargingDataVerifiableCredential]
 } as Presentation;
 
 export const rebeamVerifiablePresentation = {

--- a/apps/vc-api/test/vc-api/credential.service.spec.key.ts
+++ b/apps/vc-api/test/vc-api/credential.service.spec.key.ts
@@ -4,7 +4,8 @@ export const key = {
   kty: 'OKP',
   crv: 'Ed25519',
   x: 'gZbb93kdEoQ9Be78z7NG064wBq8Vv_0zR-qglxkiJ-g',
-  d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA'
+  d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA',
+  kid: 'zWME913jdYrILuYD-ot-jDbmzqz34HqlCUZ6CMdJnyo'
 };
 
 export const did = keyToDID('key', JSON.stringify(key)); // "did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF"
@@ -19,7 +20,8 @@ export const didDoc = {
         kty: 'OKP',
         crv: 'Ed25519',
         x: 'gZbb93kdEoQ9Be78z7NG064wBq8Vv_0zR-qglxkiJ-g',
-        d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA'
+        d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA',
+        kid: 'zWME913jdYrILuYD-ot-jDbmzqz34HqlCUZ6CMdJnyo'
       }
     }
   ]

--- a/apps/vc-api/test/vc-api/credential.service.spec.key.ts
+++ b/apps/vc-api/test/vc-api/credential.service.spec.key.ts
@@ -7,6 +7,22 @@ export const key = {
   d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA'
 };
 
-export const did = keyToDID('key', JSON.stringify(key));
+export const did = keyToDID('key', JSON.stringify(key)); // "did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF"
+export const didDoc = {
+  id: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
+  verificationMethod: [
+    {
+      id: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF#z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
+      type: 'Ed25519VerificationKey2018',
+      controller: 'did:key:z6MkoB84PJkXzFpbqtfYV5WqBKHCSDf7A1SeepwzvE36QvCF',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'gZbb93kdEoQ9Be78z7NG064wBq8Vv_0zR-qglxkiJ-g',
+        d: 'XXugDYUEtINLUefOLeztqOOtPukVIvNPreMTzl6wKgA'
+      }
+    }
+  ]
+};
 
 export const challenge = '2679f7f3-d9ff-4a7e-945c-0f30fb0765bd';

--- a/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
@@ -33,9 +33,7 @@ export const vcApiSuite = () => {
         id: 'did:example:d23dd687a7dc6787646f2eb98d0'
       }
     };
-    const options: IssueOptionsDto = {
-      verificationMethod: didDoc.verificationMethod[0].id
-    };
+    const options: IssueOptionsDto = {};
     const postResponse = await request(app.getHttpServer())
       .post('/vc-api/credentials/issue')
       .send({ credential, options })

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
@@ -15,10 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { DIDDocument } from 'did-resolver';
 import { WalletClient } from '../../../wallet-client';
 import { CredentialDto } from '../../../../src/vc-api/credentials/dtos/credential.dto';
 import { Presentation } from '../../../../src/vc-api/exchanges/types/presentation';
-import { DIDDocument } from 'did-resolver';
+import { ProvePresentationOptionsDto } from '../../../../src/vc-api/credentials/dtos/prove-presentation-options.dto';
 
 export class RebeamSupplier {
   /**
@@ -31,9 +32,8 @@ export class RebeamSupplier {
   async issueCredential(holderDidDoc: DIDDocument, walletClient: WalletClient) {
     const issuingDID = await walletClient.createDID('key');
     const credential = this.fillCredential(issuingDID.id, holderDidDoc.id);
-    const options = {};
     const issueCredentialDto = {
-      options,
+      options: {},
       credential
     };
     const vc = await walletClient.issueVC(issueCredentialDto);
@@ -42,8 +42,15 @@ export class RebeamSupplier {
       type: ['VerifiablePresentation'],
       verifiableCredential: [vc]
     };
+    const verificationMethodURI = issuingDID?.verificationMethod[0]?.id;
+    if (!verificationMethodURI) {
+      return { errors: ['verification method for issuance not available'] };
+    }
+    const presentationOptions: ProvePresentationOptionsDto = {
+      verificationMethod: verificationMethodURI
+    };
     const provePresentationDto = {
-      options,
+      options: presentationOptions,
       presentation
     };
     const returnVp = await walletClient.provePresentation(provePresentationDto);

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
@@ -23,11 +23,7 @@ import { ProvePresentationOptionsDto } from '../../../../src/vc-api/credentials/
 
 export class RebeamSupplier {
   /**
-   *
-   * TODO: get and approve presentation review
-   * @param vp
-   * @param walletClient
-   * @returns
+   * Issue credential to holder
    */
   async issueCredential(holderDidDoc: DIDDocument, walletClient: WalletClient) {
     const issuingDID = await walletClient.createDID('key');

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam-supplier.ts
@@ -31,13 +31,7 @@ export class RebeamSupplier {
   async issueCredential(holderDidDoc: DIDDocument, walletClient: WalletClient) {
     const issuingDID = await walletClient.createDID('key');
     const credential = this.fillCredential(issuingDID.id, holderDidDoc.id);
-    const verificationMethodURI = issuingDID?.verificationMethod[0]?.id;
-    if (!verificationMethodURI) {
-      return { errors: ['verification method for issuance not available'] };
-    }
-    const options = {
-      verificationMethod: verificationMethodURI
-    };
+    const options = {};
     const issueCredentialDto = {
       options,
       credential

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -21,19 +21,20 @@ import { ProofPurpose } from '@sphereon/pex';
 import { RebeamCpoNode } from './rebeam-cpo-node';
 import { app, getContinuationEndpoint, vcApiBaseUrl, walletClient } from '../../../app.e2e-spec';
 import { RebeamSupplier } from './rebeam-supplier';
-import { chargingDataCredential, presentationDefinition } from '../../credential.service.spec.data';
+import { getChargingDataCredential, presentationDefinition } from '../../credential.service.spec.data';
 import { ProvePresentationOptionsDto } from '../../../../src/vc-api/credentials/dtos/prove-presentation-options.dto';
 
 export const rebeamExchangeSuite = () => {
   it('Rebeam presentation using ed25119 signatures', async () => {
-    const holderDID = await walletClient.createDID('key');
-    const holderVerificationMethod = holderDID.verificationMethod[0].id;
+    const holderDIDDoc = await walletClient.createDID('key');
+    const holderVerificationMethod = holderDIDDoc.verificationMethod[0].id;
 
     // SUPPLIER: Issue "rebeam-customer" credential
     const supplier = new RebeamSupplier();
-    const energyContractVp = await supplier.issueCredential(holderDID, walletClient);
+    const energyContractVp = await supplier.issueCredential(holderDIDDoc, walletClient);
+    const credential = getChargingDataCredential(holderDIDDoc.id);
     const chargingDataVerifiableCredential = await walletClient.issueVC({
-      credential: chargingDataCredential,
+      credential,
       options: {}
     });
 

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -61,7 +61,6 @@ export const rebeamExchangeSuite = () => {
 
     const issuanceOptions: IssueOptionsDto = {
       proofPurpose: ProofPurpose.authentication,
-      verificationMethod: holderVerificationMethod,
       challenge: presentationVpRequest.challenge
     };
     const vp = await walletClient.provePresentation({ presentation, options: issuanceOptions });

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -17,12 +17,12 @@
 
 import * as request from 'supertest';
 import * as nock from 'nock';
-import { IssueOptionsDto } from '../../../../src/vc-api/credentials/dtos/issue-options.dto';
 import { ProofPurpose } from '@sphereon/pex';
 import { RebeamCpoNode } from './rebeam-cpo-node';
 import { app, getContinuationEndpoint, vcApiBaseUrl, walletClient } from '../../../app.e2e-spec';
 import { RebeamSupplier } from './rebeam-supplier';
 import { chargingDataCredential, presentationDefinition } from '../../credential.service.spec.data';
+import { ProvePresentationOptionsDto } from '../../../../src/vc-api/credentials/dtos/prove-presentation-options.dto';
 
 export const rebeamExchangeSuite = () => {
   it('Rebeam presentation using ed25119 signatures', async () => {
@@ -34,7 +34,7 @@ export const rebeamExchangeSuite = () => {
     const energyContractVp = await supplier.issueCredential(holderDID, walletClient);
     const chargingDataVerifiableCredential = await walletClient.issueVC({
       credential: chargingDataCredential,
-      options: { proofPurpose: ProofPurpose.authentication, verificationMethod: holderVerificationMethod }
+      options: {}
     });
 
     // CPO-NODE: Configure presentation exchange
@@ -59,11 +59,12 @@ export const rebeamExchangeSuite = () => {
       chargingDataVerifiableCredential
     ]);
 
-    const issuanceOptions: IssueOptionsDto = {
+    const presentationOptions: ProvePresentationOptionsDto = {
       proofPurpose: ProofPurpose.authentication,
+      verificationMethod: holderVerificationMethod,
       challenge: presentationVpRequest.challenge
     };
-    const vp = await walletClient.provePresentation({ presentation, options: issuanceOptions });
+    const vp = await walletClient.provePresentation({ presentation, options: presentationOptions });
 
     // Holder submits presentation
     await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false);

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card-issuance.exchange.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card-issuance.exchange.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { plainToClass } from 'class-transformer';
 import { WalletClient } from '../../../wallet-client';
 import { VerifiablePresentationDto } from '../../../../src/vc-api/credentials/dtos/verifiable-presentation.dto';
 import { CredentialDto } from '../../../../src/vc-api/credentials/dtos/credential.dto';
@@ -22,7 +23,7 @@ import { Presentation } from '../../../../src/vc-api/exchanges/types/presentatio
 import { ExchangeDefinitionDto } from '../../../../src/vc-api/exchanges/dtos/exchange-definition.dto';
 import { VpRequestInteractServiceType } from '../../../../src/vc-api/exchanges/types/vp-request-interact-service-type';
 import { VpRequestQueryType } from '../../../../src/vc-api/exchanges/types/vp-request-query-type';
-import { plainToClass } from 'class-transformer';
+import { ProvePresentationOptionsDto } from '../../../../src/vc-api/credentials/dtos/prove-presentation-options.dto';
 
 export class ResidentCardIssuance {
   #exchangeId = 'permanent-resident-card-issuance';
@@ -65,9 +66,8 @@ export class ResidentCardIssuance {
     }
     const issuingDID = await walletClient.createDID('key');
     const credential = this.fillCredential(issuingDID.id, vp.holder);
-    const options = {};
     const issueCredentialDto = {
-      options,
+      options: {},
       credential
     };
     const vc = await walletClient.issueVC(issueCredentialDto);
@@ -76,8 +76,15 @@ export class ResidentCardIssuance {
       type: ['VerifiablePresentation'],
       verifiableCredential: [vc]
     };
+    const verificationMethodURI = issuingDID?.verificationMethod[0]?.id;
+    if (!verificationMethodURI) {
+      return { errors: ['verification method for issuance not available'] };
+    }
+    const presentationOptions: ProvePresentationOptionsDto = {
+      verificationMethod: verificationMethodURI
+    };
     const provePresentationDto = {
-      options,
+      options: presentationOptions,
       presentation
     };
     const returnVp = await walletClient.provePresentation(provePresentationDto);

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card-issuance.exchange.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card-issuance.exchange.ts
@@ -65,13 +65,7 @@ export class ResidentCardIssuance {
     }
     const issuingDID = await walletClient.createDID('key');
     const credential = this.fillCredential(issuingDID.id, vp.holder);
-    const verificationMethodURI = issuingDID?.verificationMethod[0]?.id;
-    if (!verificationMethodURI) {
-      return { errors: ['verification method for issuance not available'] };
-    }
-    const options = {
-      verificationMethod: verificationMethodURI
-    };
+    const options = {};
     const issueCredentialDto = {
       options,
       credential

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -27,6 +27,7 @@ import {
 import { ResidentCardIssuance } from './resident-card-issuance.exchange';
 import { ResidentCardPresentation } from './resident-card-presentation.exchange';
 import { app, getContinuationEndpoint, vcApiBaseUrl, walletClient } from '../../../app.e2e-spec';
+import { ProvePresentationOptionsDto } from 'src/vc-api/credentials/dtos/prove-presentation-options.dto';
 
 export const residentCardExchangeSuite = () => {
   it('should support Resident Card issuance and presentation', async () => {
@@ -48,7 +49,9 @@ export const residentCardExchangeSuite = () => {
     // As holder, create new DID and presentation to authentication as this DID
     // DID auth presentation: https://github.com/spruceid/didkit/blob/c5c422f2469c2c5cc2f6e6d8746e95b552fce3ed/lib/web/src/lib.rs#L382
     const holderDIDDoc = await walletClient.createDID('key');
-    const options: IssueOptionsDto = {
+    const holderVerificationMethod = holderDIDDoc.verificationMethod[0].id;
+    const options: ProvePresentationOptionsDto = {
+      verificationMethod: holderVerificationMethod,
       proofPurpose: ProofPurpose.authentication,
       challenge: issuanceVpRequest.challenge
     };
@@ -120,12 +123,13 @@ export const residentCardExchangeSuite = () => {
       verifiableCredential: [issuedVc],
       holder: holderDIDDoc.id
     };
-    const issuanceOptions: IssueOptionsDto = {
+    const presentationOptions: ProvePresentationOptionsDto = {
+      verificationMethod: holderVerificationMethod,
       proofPurpose: ProofPurpose.authentication,
       created: '2021-11-16T14:52:19.514Z',
       challenge: presentationVpRequest.challenge
     };
-    const vp = await walletClient.provePresentation({ presentation, options: issuanceOptions });
+    const vp = await walletClient.provePresentation({ presentation, options: presentationOptions });
 
     // Holder submits presentation
     await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false);

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -15,17 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ProofPurpose } from '@sphereon/pex';
 import * as request from 'supertest';
 import * as nock from 'nock';
 import { IssueOptionsDto } from '../../../../src/vc-api/credentials/dtos/issue-options.dto';
-import { ResidentCardIssuance } from './resident-card-issuance.exchange';
-import { ProofPurpose } from '@sphereon/pex';
-import { ResidentCardPresentation } from './resident-card-presentation.exchange';
-import { app, getContinuationEndpoint, vcApiBaseUrl, walletClient } from '../../../app.e2e-spec';
+import { PresentationDto } from '../../../../src/vc-api/credentials/dtos/presentation.dto';
 import {
   ReviewResult,
   SubmissionReviewDto
 } from '../../../../src/vc-api/exchanges/dtos/submission-review.dto';
+import { ResidentCardIssuance } from './resident-card-issuance.exchange';
+import { ResidentCardPresentation } from './resident-card-presentation.exchange';
+import { app, getContinuationEndpoint, vcApiBaseUrl, walletClient } from '../../../app.e2e-spec';
 
 export const residentCardExchangeSuite = () => {
   it('should support Resident Card issuance and presentation', async () => {
@@ -46,27 +47,20 @@ export const residentCardExchangeSuite = () => {
 
     // As holder, create new DID and presentation to authentication as this DID
     // DID auth presentation: https://github.com/spruceid/didkit/blob/c5c422f2469c2c5cc2f6e6d8746e95b552fce3ed/lib/web/src/lib.rs#L382
-    const holderDID = await walletClient.createDID('key');
-    const holderVerificationMethod = holderDID.verificationMethod[0].id;
+    const holderDIDDoc = await walletClient.createDID('key');
     const options: IssueOptionsDto = {
-      verificationMethod: holderVerificationMethod,
       proofPurpose: ProofPurpose.authentication,
       challenge: issuanceVpRequest.challenge
     };
     const didAuthResponse = await request(app.getHttpServer())
       .post(`${vcApiBaseUrl}/presentations/prove/authentication`)
-      .send({ did: holderDID.id, options })
+      .send({ did: holderDIDDoc.id, options })
       .expect(201);
     const didAuthVp = didAuthResponse.body;
     expect(didAuthVp).toBeDefined();
 
     // As holder, continue exchange by submitting did auth presention
-    const firstContinuationResponse = await walletClient.continueExchange(
-      issuanceExchangeContinuationEndpoint,
-      didAuthVp,
-      true
-    );
-    const submissionCheckEndpoint = firstContinuationResponse.vpRequest.interact.service[0].serviceEndpoint;
+    await walletClient.continueExchange(issuanceExchangeContinuationEndpoint, didAuthVp, true);
 
     // As the issuer, get the transaction
     // TODO TODO TODO!!! How does the issuer know the transactionId? -> Maybe can rely on notification
@@ -117,17 +111,17 @@ export const residentCardExchangeSuite = () => {
 
     // Holder should parse VP Request for correct credentials...
     // Assume that holder figures out which VC they need and can prep presentation
-    const presentation = {
+    const presentation: PresentationDto = {
       '@context': [
         'https://www.w3.org/2018/credentials/v1',
         'https://www.w3.org/2018/credentials/examples/v1'
       ],
       type: ['VerifiablePresentation'],
-      verifiableCredential: [issuedVc]
+      verifiableCredential: [issuedVc],
+      holder: holderDIDDoc.id
     };
     const issuanceOptions: IssueOptionsDto = {
       proofPurpose: ProofPurpose.authentication,
-      verificationMethod: holderVerificationMethod,
       created: '2021-11-16T14:52:19.514Z',
       challenge: presentationVpRequest.challenge
     };


### PR DESCRIPTION
The VC-API spec changed to not allow `type`, `verificationMethod` and `proofPurpose` anymore for issueCredential and so this is removed from our implementation https://github.com/w3c-ccg/vc-api/pull/263/files
Prove presentation options still have the properties though so this PR separate the issuance options from presentation proof options.