### PR TITLE
feat: return 202 status code on continue exchange

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -71,6 +71,23 @@
         "tags": ["vc-api"]
       }
     },
+    "/vc-api/credentials/verify": {
+      "post": {
+        "operationId": "VcApiController_verifyCredential",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/VerifyCredentialDto" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "Verifiable Credential successfully verified" },
+          "400": { "description": "Invalid input" }
+        },
+        "tags": ["vc-api"]
+      }
+    },
     "/vc-api/presentations/prove/authentication": {
       "post": {
         "operationId": "VcApiController_proveAuthenticationPresentation",
@@ -102,6 +119,23 @@
           }
         },
         "responses": { "201": { "description": "" } },
+        "tags": ["vc-api"]
+      }
+    },
+    "/vc-api/presentations/verify": {
+      "post": {
+        "operationId": "VcApiController_verifyPresentation",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/VerifyPresentationDto" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "Verifiable Presentation successfully verified!" },
+          "400": { "description": "Invalid or malformed input" }
+        },
         "tags": ["vc-api"]
       }
     },
@@ -142,7 +176,12 @@
             "application/json": { "schema": { "$ref": "#/components/schemas/VerifiablePresentationDto" } }
           }
         },
-        "responses": { "200": { "description": "" } },
+        "responses": {
+          "200": { "description": "Verifiable Presentation successfully submitted and verified" },
+          "202": {
+            "description": "Verifiable Presentation successfully submitted. Further review in progress."
+          }
+        },
         "tags": ["vc-api"]
       },
       "get": {
@@ -180,8 +219,10 @@
       "KeyPairDto": { "type": "object", "properties": {} },
       "CreateDidOptionsDto": { "type": "object", "properties": {} },
       "IssueCredentialDto": { "type": "object", "properties": {} },
+      "VerifyCredentialDto": { "type": "object", "properties": {} },
       "AuthenticateDto": { "type": "object", "properties": {} },
       "ProvePresentationDto": { "type": "object", "properties": {} },
+      "VerifyPresentationDto": { "type": "object", "properties": {} },
       "ExchangeDefinitionDto": { "type": "object", "properties": {} },
       "VerifiablePresentationDto": { "type": "object", "properties": {} },
       "SubmissionReviewDto": { "type": "object", "properties": {} }

--- a/apps/vc-api/docs/tutorials/resident-card-tutorial.md
+++ b/apps/vc-api/docs/tutorials/resident-card-tutorial.md
@@ -406,7 +406,7 @@ This response indicates that the client attempt to continue the exchange again (
 
 **Expected Response HTTP Status Code**
 
-`200 OK`
+`202 Accepted`
 
 #### 1.7 [Authority portal] Check for notification of submitted presentation
 

--- a/apps/vc-api/src/vc-api/exchanges/dtos/exchange-response.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/exchange-response.dto.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { VerifiablePresentationDto } from 'src/vc-api/credentials/dtos/verifiable-presentation.dto';
 import { VpRequestDto } from './vp-request.dto';
 
@@ -46,4 +46,10 @@ export class ExchangeResponseDto {
   @ValidateNested()
   @IsOptional()
   vp?: VerifiablePresentationDto;
+
+  /**
+   * True if an exchange submission is currently being processed or reviewed asyncronously
+   */
+  @IsBoolean()
+  processingInProgress: boolean;
 }

--- a/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -121,7 +121,8 @@ export class TransactionEntity {
     if (errors.length > 0) {
       return {
         response: {
-          errors
+          errors,
+          processingInProgress: false
         },
         callback: []
       };
@@ -142,7 +143,8 @@ export class TransactionEntity {
               challenge: uuidv4(),
               query: [],
               interact: this.vpRequest.interact // Holder should query the same endpoint again to check if it has been reviewed
-            }
+            },
+            processingInProgress: true
           },
           callback: this.callback
         };
@@ -154,7 +156,8 @@ export class TransactionEntity {
         return {
           response: {
             errors: [],
-            vp: this.presentationReview?.VP
+            vp: this.presentationReview?.VP,
+            processingInProgress: false
           },
           callback: []
         };
@@ -164,7 +167,8 @@ export class TransactionEntity {
       this.presentationSubmission = new PresentationSubmissionEntity(presentation, verificationResult);
       return {
         response: {
-          errors: []
+          errors: [],
+          processingInProgress: false
         },
         callback: this.callback
       };

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -88,7 +88,7 @@ export class ExchangeService {
   public async continueExchange(
     verifiablePresentation: VerifiablePresentationDto,
     transactionId: string
-  ): Promise<ExchangeResponseDto> {
+  ): Promise<ExchangeResponseDto | null> {
     const transactionQuery = await this.getExchangeTransaction(transactionId);
     if (transactionQuery.errors.length > 0 || !transactionQuery.transaction) {
       return {
@@ -96,6 +96,7 @@ export class ExchangeService {
       };
     }
     const transaction = transactionQuery.transaction;
+
     const { response, callback } = await transaction.processPresentation(
       verifiablePresentation,
       this.vpSubmissionVerifierService
@@ -109,7 +110,8 @@ export class ExchangeService {
         error: (e) => Logger.error(inspect(e))
       });
     });
-    return response;
+
+    return transaction.presentationReview ? response : null;
   }
 
   public async getExchange(exchangeId: string): Promise<{ errors: string[]; exchange?: ExchangeEntity }> {

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -174,11 +174,11 @@ export class VcApiController {
     const response = await this.exchangeService.continueExchange(presentation, transactionId);
 
     if (response.processingInProgress) {
-      // Retry-After 5 seconds
-      return res.status(202).setHeader('Retry-After', 5).send();
+      // Currently 5 second retry time is hardcoded but it could be dynamic based on the use case in the future
+      res.status(202).setHeader('Retry-After', 5);
     }
 
-    return response;
+    return res.send(response);
   }
 
   /**

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -173,7 +173,7 @@ export class VcApiController {
   ): Promise<ExchangeResponseDto | Response> {
     const response = await this.exchangeService.continueExchange(presentation, transactionId);
 
-    if (!response) {
+    if (response.processingInProgress) {
       // Retry-After 5 seconds
       return res.status(202).setHeader('Retry-After', 5).send();
     }

--- a/apps/vc-api/src/vc-api/vc-api.controller.ts
+++ b/apps/vc-api/src/vc-api/vc-api.controller.ts
@@ -165,6 +165,11 @@ export class VcApiController {
    * @returns
    */
   @Put('/exchanges/:exchangeId/:transactionId')
+  @ApiResponse({ status: 200, description: 'Verifiable Presentation successfully submitted and verified' })
+  @ApiResponse({
+    status: 202,
+    description: 'Verifiable Presentation successfully submitted. Further review in progress.'
+  })
   async continueExchange(
     @Param('exchangeId') exchangeId: string,
     @Param('transactionId') transactionId: string,

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -68,7 +68,7 @@ export const rebeamExchangeSuite = () => {
     const vp = await walletClient.provePresentation({ presentation, options: presentationOptions });
 
     // Holder submits presentation
-    await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false);
+    await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false, true);
     scope.done();
   });
 

--- a/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/rebeam/rebeam.e2e-suite.ts
@@ -68,7 +68,7 @@ export const rebeamExchangeSuite = () => {
     const vp = await walletClient.provePresentation({ presentation, options: presentationOptions });
 
     // Holder submits presentation
-    await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false, true);
+    await walletClient.continueExchange(presentationExchangeContinuationEndpoint, vp, false);
     scope.done();
   });
 

--- a/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/exchanges/resident-card/resident-card.e2e-suite.ts
@@ -63,7 +63,7 @@ export const residentCardExchangeSuite = () => {
     expect(didAuthVp).toBeDefined();
 
     // As holder, continue exchange by submitting did auth presention
-    await walletClient.continueExchange(issuanceExchangeContinuationEndpoint, didAuthVp, true);
+    await walletClient.continueExchange(issuanceExchangeContinuationEndpoint, didAuthVp, true, true);
 
     // As the issuer, get the transaction
     // TODO TODO TODO!!! How does the issuer know the transactionId? -> Maybe can rely on notification

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -131,12 +131,13 @@ export class WalletClient {
   async continueExchange(
     exchangeContinuationEndpoint: string,
     vp: VerifiablePresentationDto,
-    expectsVpRequest: boolean
+    expectsVpRequest: boolean,
+    expectsProcessionInProgress: boolean = false
   ) {
     const continueExchangeResponse = await request(this.#app.getHttpServer())
       .put(exchangeContinuationEndpoint)
       .send(vp)
-      .expect(200);
+      .expect(expectsProcessionInProgress ? 202 : 200);
     expect(continueExchangeResponse.body.errors).toHaveLength(0);
     if (expectsVpRequest) {
       expect(continueExchangeResponse.body.vpRequest).toBeDefined();


### PR DESCRIPTION
Return in continue exchange endpoint a 202 status code with
`retry-after` header when a review has not been sent. Hardocde retry
after value to 5 seconds.