### PR TITLE
feat(did): register DID with keyId

### DIFF
--- a/apps/vc-api/README.md
+++ b/apps/vc-api/README.md
@@ -84,6 +84,11 @@ The DID Module in the [vc-api](./apps/vc-api) offers the generation of DIDs and 
 ### Key Module
 The key module is kept separate from the DID module because it's plausible that key module will be provided by a different service (i.e. a dedicated KMS) at some point.
 
+#### Key Import/Export
+
+The key module allows for the import and export of key pairs.
+A tutorial demonstrating this available here: [Key Export/Import Tutorial](./docs/tutorials/key-export-import-tutorial.md)
+
 ## Database
 Currently, the app uses an **in-memory DB** for now for app execution and tests.
 The rationale for this for executions that, as the app is only being used in a demo context, it is not necessary to persist data between executions.

--- a/apps/vc-api/docs/tutorials/key-export-import-tutorial.md
+++ b/apps/vc-api/docs/tutorials/key-export-import-tutorial.md
@@ -22,13 +22,16 @@
 ### Technical workflows
 
 Steps covered in this tutorial:
-1. DID Generation
-1. Key Export
-1. Key Import
+
+[1.1 Create DID](#11-create-a-did)
+[1.2 Export Key](#12-export-key)
+
+[2.1 Import Key](#21-import-key)
+[2.2 Register DID](#22-register-did)
 
 ## Steps
 
-### 1 Create a DID
+### 1.1 Create a DID
 
 Let's create a new DID.
 
@@ -78,7 +81,7 @@ Response body should be similar to the one below but with a different `did`.
 
 `201 Created`
 
-### 2 Export Key
+### 1.2 Export Key
 
 The key can be exported by using the key id located at `verificationMethod.publicKeyJwk.kid` in the DID document from the previous step.
 
@@ -116,9 +119,9 @@ Send the request as described below.
 }
 ```
 
-### 3 Import Key
+### 2.1 Import Key
 
-The key can be imported by providing the `privateKey` and `publicKey`.
+A key can be imported by providing the `privateKey` and `publicKey`.
 
 Send the request as described below.
 
@@ -136,15 +139,15 @@ Send the request as described below.
 {
   "privateKey": {
     "crv": "Ed25519",
-    "d": "31DlEXUMXAvcAuTpBl5cPlPavrzo4I9s63WiT0ni8zg",
-    "x": "5uRJcJ67oMzfaB3XXQeLNj_Bv3ew1mmV8lItQ1k52og",
+    "d": "XYinvK___oQmhBvL0LDJPmryrvXDNKebtFznjri2YWk",
+    "x": "E5ljjWvsZZ2NYpDr7QDbit-WWKMxbzn3YgMjRa1dShQ",
     "kty": "OKP"
   },
   "publicKey": {
     "crv": "Ed25519",
-    "x": "5uRJcJ67oMzfaB3XXQeLNj_Bv3ew1mmV8lItQ1k52og",
+    "x": "E5ljjWvsZZ2NYpDr7QDbit-WWKMxbzn3YgMjRa1dShQ",
     "kty": "OKP",
-    "kid": "KizsQVRSz6l73kFnrAHJ1V6c5YQS6I0SS9zyZMNNdRs"
+    "kid": "MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4"
   }
 }
 ```
@@ -153,8 +156,52 @@ Send the request as described below.
 
 ```json
 {
-  "keyId": "KizsQVRSz6l73kFnrAHJ1V6c5YQS6I0SS9zyZMNNdRs"
+  "keyId": "MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4"
 }
 ```
 
+### 2.2 Register DID
 
+A key can be registered against a key known to the server.
+
+Send the request as described below.
+
+**Request URL**
+
+`{VC API base url}/did`
+
+**HTTP Verb**
+
+`POST`
+
+**Request Body**
+
+```json
+{
+  "method": "key",
+  "keyId": "MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4"
+}
+```
+
+**Sample Expected Response Body**
+
+The DID Document of the registered DID.
+
+```json
+{
+  "id": "did:key:z6MkfmmT2qF4bXwErwQ1dgWLxDLvCvGqGYJnudNULp7t63X9",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkfmmT2qF4bXwErwQ1dgWLxDLvCvGqGYJnudNULp7t63X9#z6MkfmmT2qF4bXwErwQ1dgWLxDLvCvGqGYJnudNULp7t63X9",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:key:z6MkfmmT2qF4bXwErwQ1dgWLxDLvCvGqGYJnudNULp7t63X9",
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "E5ljjWvsZZ2NYpDr7QDbit-WWKMxbzn3YgMjRa1dShQ",
+        "kty": "OKP",
+        "kid": "MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4"
+      }
+    }
+  ]
+}
+```

--- a/apps/vc-api/src/did/did.controller.spec.ts
+++ b/apps/vc-api/src/did/did.controller.spec.ts
@@ -23,6 +23,7 @@ import { DIDController } from './did.controller';
 import { DIDService } from './did.service';
 import { DIDDocumentEntity } from './entities/did-document.entity';
 import { VerificationMethodEntity } from './entities/verification-method.entity';
+import { DidMethod } from './types/did-method';
 
 describe('DidController', () => {
   let controller: DIDController;
@@ -47,7 +48,7 @@ describe('DidController', () => {
 
   describe('create', () => {
     it('should create an ethr DID', async () => {
-      const did = await controller.create({ method: 'ethr' });
+      const did = await controller.create({ method: DidMethod.ethr });
     });
   });
 });

--- a/apps/vc-api/src/did/did.controller.ts
+++ b/apps/vc-api/src/did/did.controller.ts
@@ -20,6 +20,7 @@ import { DIDService } from './did.service';
 import { DIDDocument, VerificationMethod } from 'did-resolver';
 import { ApiTags } from '@nestjs/swagger';
 import { CreateDidOptionsDto } from './dto/create-did-options.dto';
+import { DidMethod } from './types/did-method';
 
 @ApiTags('did')
 @Controller('did')
@@ -33,10 +34,13 @@ export class DIDController {
    */
   @Post()
   async create(@Body() body: CreateDidOptionsDto): Promise<DIDDocument> {
-    if (body.method === 'ethr') {
+    if (body.method === DidMethod.ethr) {
       return await this.didService.generateEthrDID();
     }
-    if (body.method === 'key') {
+    if (body.method === DidMethod.key) {
+      if (body.keyId) {
+        return await this.didService.registerKeyDID(body.keyId);
+      }
       return await this.didService.generateKeyDID();
     }
     throw new Error('Requested DID method not supported');

--- a/apps/vc-api/src/did/dto/create-did-options.dto.ts
+++ b/apps/vc-api/src/did/dto/create-did-options.dto.ts
@@ -27,7 +27,7 @@ export class CreateDidOptionsDto {
    * Must be one of "key" or "ethr"
    */
   @IsEnum(DidMethod)
-  method: string;
+  method: DidMethod;
 
   /**
    * id of key (for example, JWK thumbprint).

--- a/apps/vc-api/src/did/types/did-method.ts
+++ b/apps/vc-api/src/did/types/did-method.ts
@@ -15,27 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsEnum, IsOptional, IsString } from 'class-validator';
-import { DidMethod } from '../types/did-method';
-
-/**
- * Create DID options
- */
-export class CreateDidOptionsDto {
-  /**
-   * DID Method to create.
-   * Must be one of "key" or "ethr"
-   */
-  @IsEnum(DidMethod)
-  method: string;
-
-  /**
-   * id of key (for example, JWK thumbprint).
-   * This key must be known to the server already.
-   * If provided, DID will be created using this key.
-   * Currently only supported for did:key.
-   */
-  @IsString()
-  @IsOptional()
-  keyId?: string;
+export enum DidMethod {
+  key = 'key',
+  ethr = 'ethr'
 }

--- a/apps/vc-api/src/key/dtos/key-description.dto.ts
+++ b/apps/vc-api/src/key/dtos/key-description.dto.ts
@@ -16,7 +16,7 @@
  */
 
 import { IKeyDescription } from '@energyweb/w3c-ccg-webkms';
-import { IsObject } from 'class-validator';
+import { IsString } from 'class-validator';
 
 /**
  * KeyPair
@@ -25,6 +25,6 @@ export class KeyDescriptionDto implements IKeyDescription {
   /**
    * id of key (for example, JWK thumbprint)
    */
-  @IsObject()
+  @IsString()
   public keyId: string;
 }

--- a/apps/vc-api/test/key/key.e2e-suite.ts
+++ b/apps/vc-api/test/key/key.e2e-suite.ts
@@ -47,4 +47,31 @@ export const keySuite = () => {
     const exportedKey = await walletClient.exportKey(keyDescription.keyId);
     expect(exportedKey).toEqual(keyPair);
   });
+
+  it('should register a did:key from an imported key', async () => {
+    const keyPair = {
+      publicKeyThumbprint: 'MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4',
+      privateKey: {
+        crv: 'Ed25519',
+        d: 'XYinvK___oQmhBvL0LDJPmryrvXDNKebtFznjri2YWk',
+        x: 'E5ljjWvsZZ2NYpDr7QDbit-WWKMxbzn3YgMjRa1dShQ',
+        kty: 'OKP'
+      },
+      publicKey: {
+        crv: 'Ed25519',
+        x: 'E5ljjWvsZZ2NYpDr7QDbit-WWKMxbzn3YgMjRa1dShQ',
+        kty: 'OKP',
+        kid: 'MW-TUkCospd6AC16JkoD1-Iun1GxGLGSv6Z-48CfSj4'
+      }
+    };
+    const keyDescription = await walletClient.importKey(keyPair);
+    const createdDID = await walletClient.createDID('key', keyDescription.keyId);
+    expect(createdDID.verificationMethod[0].publicKeyJwk.kid).toEqual(keyDescription.keyId);
+
+    // Should be able to reimport and create.
+    // Operations are idempotent.
+    const keyDescription2 = await walletClient.importKey(keyPair);
+    const createdDID2 = await walletClient.createDID('key', keyDescription2.keyId);
+    expect(createdDID2.verificationMethod[0].publicKeyJwk.kid).toEqual(keyDescription2.keyId);
+  });
 };

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -60,10 +60,10 @@ export class WalletClient {
     return postResponse.body;
   }
 
-  async createDID(requestedMethod: string): Promise<DIDDocument> {
+  async createDID(requestedMethod: string, keyId?: string): Promise<DIDDocument> {
     const postResponse = await request(this.#app.getHttpServer())
       .post('/did')
-      .send({ method: requestedMethod })
+      .send({ method: requestedMethod, keyId })
       .expect(201);
     expect(postResponse.body).toHaveProperty('id');
     expect(postResponse.body).toHaveProperty('verificationMethod');


### PR DESCRIPTION
Can register a did:key with a key known to the server. See https://github.com/energywebfoundation/ssi/blob/feat/IVA-30/register-did-with-keyid/apps/vc-api/docs/tutorials/key-export-import-tutorial.md#22-register-did for example