### PR TITLE
feat: POST /vc-api/exchanges "409 Conflict" response when collision detected

### DIFF
--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.spec.ts
@@ -58,6 +58,7 @@ describe('ExchangeService', () => {
     findOne: jest.fn(() => transaction),
     save: jest.fn((entity) => {
       transaction = entity;
+      return entity;
     })
   }));
 
@@ -68,6 +69,7 @@ describe('ExchangeService', () => {
       findOne: jest.fn(() => exchange),
       save: jest.fn((entity: ExchangeEntity) => {
         exchange = entity;
+        return entity;
       })
     };
   });

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.spec.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.spec.ts
@@ -60,13 +60,17 @@ describe('ExchangeService', () => {
       transaction = entity;
     })
   }));
-  let exchange: ExchangeEntity;
-  const repositoryMockFactory = jest.fn(() => ({
-    findOne: jest.fn(() => exchange),
-    save: jest.fn((entity) => {
-      exchange = entity;
-    })
-  }));
+
+  const repositoryMockFactory = jest.fn(() => {
+    let exchange: ExchangeEntity;
+
+    return {
+      findOne: jest.fn(() => exchange),
+      save: jest.fn((entity: ExchangeEntity) => {
+        exchange = entity;
+      })
+    };
+  });
 
   const mockHttpService = {
     post: jest.fn(() => {

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -16,7 +16,6 @@
  */
 
 import { Injectable, Logger, ConflictException } from '@nestjs/common';
-import { isNil } from '@nestjs/common/utils/shared.utils';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -45,7 +44,7 @@ export class ExchangeService {
   ) {}
 
   public async createExchange(exchangeDefinitionDto: ExchangeDefinitionDto) {
-    if (!isNil(await this.exchangeRepository.findOne(exchangeDefinitionDto.exchangeId))) {
+    if (!!(await this.exchangeRepository.findOne(exchangeDefinitionDto.exchangeId))) {
       throw new ConflictException(`exchangeId='${exchangeDefinitionDto.exchangeId}' already exists`);
     }
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, ConflictException } from '@nestjs/common';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -44,6 +45,10 @@ export class ExchangeService {
   ) {}
 
   public async createExchange(exchangeDefinitionDto: ExchangeDefinitionDto) {
+    if (!isNil(await this.exchangeRepository.findOne(exchangeDefinitionDto.exchangeId))) {
+      throw new ConflictException(`exchangeId='${exchangeDefinitionDto.exchangeId}' already exists`);
+    }
+
     const exchange = new ExchangeEntity(exchangeDefinitionDto);
     await this.exchangeRepository.save(exchange);
     return {

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -44,7 +44,7 @@ export class ExchangeService {
   ) {}
 
   public async createExchange(exchangeDefinitionDto: ExchangeDefinitionDto) {
-    if (!!(await this.exchangeRepository.findOne(exchangeDefinitionDto.exchangeId))) {
+    if (await this.exchangeRepository.findOne(exchangeDefinitionDto.exchangeId)) {
       throw new ConflictException(`exchangeId='${exchangeDefinitionDto.exchangeId}' already exists`);
     }
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Injectable, Logger, ConflictException } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';

--- a/apps/vc-api/test/app.e2e-spec.ts
+++ b/apps/vc-api/test/app.e2e-spec.ts
@@ -25,6 +25,8 @@ import { VpRequestDto } from '../src/vc-api/exchanges/dtos/vp-request.dto';
 import { rebeamExchangeSuite } from './vc-api/exchanges/rebeam/rebeam.e2e-suite';
 import { vcApiSuite } from './vc-api/credentials/vc-api.e2e-suite';
 import { keySuite } from './key/key.e2e-suite';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ExchangeEntity } from '../src/vc-api/exchanges/entities/exchange.entity';
 
 // Increasing timeout for debugging
 // Should only affect this file https://jestjs.io/docs/jest-object#jestsettimeouttimeout
@@ -44,6 +46,10 @@ describe('App (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe()); // https://github.com/nestjs/nest/issues/5264
     await app.init();
     walletClient = new WalletClient(app);
+
+    //TODO: reset the database fully
+    const exchangeRepository = app.get(getRepositoryToken(ExchangeEntity));
+    await exchangeRepository.clear();
   });
 
   describe('DID (e2e)', didSuite);


### PR DESCRIPTION
This PR adds logic to the `POST /vc-api/exchanges` endpoint to respond with "409 Conflict" response when submitting exchangeId already used.

TODO:

- [x] adjusting tests failing after update