### PR TITLE
chore: upgrading @rushstack/eslint-config to v2.6

### DIFF
--- a/apps/vc-api/package.json
+++ b/apps/vc-api/package.json
@@ -70,7 +70,7 @@
     "typescript": "^4.0.0",
     "nock": "~13.2.0",
     "@sphereon/pex-models": "~1.1.0",
-    "@rushstack/eslint-config": "~2.3.0"
+    "@rushstack/eslint-config": "~2.6.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17,7 +17,7 @@ specifiers:
   '@rush-temp/ssi-did': file:./projects/ssi-did.tgz
   '@rush-temp/ssi-vc-api': file:./projects/ssi-vc-api.tgz
   '@rush-temp/w3c-ccg-webkms': file:./projects/w3c-ccg-webkms.tgz
-  '@rushstack/eslint-config': ~2.3.0
+  '@rushstack/eslint-config': ~2.6.0
   '@sphereon/pex': ~1.1.0
   '@sphereon/pex-models': ~1.1.0
   '@spruceid/didkit-wasm-node': ~0.2.0
@@ -48,7 +48,7 @@ specifiers:
   rxjs: ^7.0.0
   source-map-support: ^0.5.0
   supertest: ^6.0.0
-  swagger-ui-express: ~4.4.0
+  swagger-ui-express: ~4.5.0
   ts-jest: ^27.0.0
   ts-loader: ^9.0.0
   ts-node: ^10.0.0
@@ -68,14 +68,14 @@ dependencies:
   '@nestjs/platform-express': 8.4.7_fce4c3b686c1225eb94686491d30b061
   '@nestjs/schematics': 8.0.11_typescript@4.7.4
   '@nestjs/serve-static': 2.2.2_fce4c3b686c1225eb94686491d30b061
-  '@nestjs/swagger': 5.1.5_d698c50e080e28585857283d96ea096d
+  '@nestjs/swagger': 5.1.5_ce4055f8a70424510229f2128b9d2f34
   '@nestjs/testing': 8.4.7_c1bddf0102e0d68dc342d4afcbe21907
   '@nestjs/typeorm': 8.0.4_4967a077601f378d566b47f3ee68696d
   '@rush-temp/credential-from-input-descriptor': file:projects/credential-from-input-descriptor.tgz_babel-jest@26.6.3
   '@rush-temp/ssi-did': file:projects/ssi-did.tgz_ts-node@10.8.1
   '@rush-temp/ssi-vc-api': file:projects/ssi-vc-api.tgz_babel-jest@26.6.3
   '@rush-temp/w3c-ccg-webkms': file:projects/w3c-ccg-webkms.tgz
-  '@rushstack/eslint-config': 2.3.4_eslint@8.19.0+typescript@4.7.4
+  '@rushstack/eslint-config': 2.6.2_eslint@8.19.0+typescript@4.7.4
   '@sphereon/pex': 1.1.2
   '@sphereon/pex-models': 1.1.0
   '@spruceid/didkit-wasm-node': 0.2.1
@@ -106,7 +106,7 @@ dependencies:
   rxjs: 7.5.5
   source-map-support: 0.5.21
   supertest: 6.2.3
-  swagger-ui-express: 4.4.0
+  swagger-ui-express: 4.5.0
   ts-jest: 27.1.5_d72aeffe33666a81c9d394a1de77d638
   ts-loader: 9.3.1_typescript@4.7.4
   ts-node: 10.8.1_841f2a74d64cdda652a10d589e346265
@@ -1782,32 +1782,6 @@ packages:
       - class-validator
     dev: false
 
-  /@nestjs/swagger/5.1.5_d698c50e080e28585857283d96ea096d:
-    resolution: {integrity: sha512-jvsgciVEFcYVVEuLdNAmgJDpFSQzIoukg+Ovz1vJ97OeCprx0sVhmocn13nCl/dEwIkwoM3eby9OiaccX0A+3A==}
-    peerDependencies:
-      '@nestjs/common': ^8.0.0
-      '@nestjs/core': ^8.0.0
-      fastify-swagger: '*'
-      reflect-metadata: ^0.1.12
-      swagger-ui-express: '*'
-    peerDependenciesMeta:
-      fastify-swagger:
-        optional: true
-      swagger-ui-express:
-        optional: true
-    dependencies:
-      '@nestjs/common': 8.4.7_5199533202e21c7185c9d97f881e2827
-      '@nestjs/core': 8.4.7_2aa064eef171d5a7957432d22e4b3f20
-      '@nestjs/mapped-types': 1.0.0_fe6df273c9388b4b76b6a58eed062952
-      lodash: 4.17.21
-      path-to-regexp: 3.2.0
-      reflect-metadata: 0.1.13
-      swagger-ui-express: 4.4.0
-    transitivePeerDependencies:
-      - class-transformer
-      - class-validator
-    dev: false
-
   /@nestjs/testing/8.4.7_c1bddf0102e0d68dc342d4afcbe21907:
     resolution: {integrity: sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==}
     peerDependencies:
@@ -1877,74 +1851,74 @@ packages:
       - encoding
     dev: false
 
-  /@rushstack/eslint-config/2.3.4_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-mwEfj3e260slxM57A2eMtkNpVM9J2iMGoqzWfD4hHtO+dcZT6rEeYG4djwj61ZriNJdAY8QIMMhfuID/xV+cyw==}
+  /@rushstack/eslint-config/2.6.2_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-EcZENq5HlXe5XN9oFZ90K8y946zBXRgliNhy+378H0oK00v3FYADj8aSisEHS5OWz4HO0hYWe6IU57CNg+syYQ==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=3.0.0'
     dependencies:
-      '@rushstack/eslint-patch': 1.0.6
-      '@rushstack/eslint-plugin': 0.7.3_eslint@8.19.0+typescript@4.7.4
-      '@rushstack/eslint-plugin-packlets': 0.2.2_eslint@8.19.0+typescript@4.7.4
-      '@rushstack/eslint-plugin-security': 0.1.4_eslint@8.19.0+typescript@4.7.4
-      '@typescript-eslint/eslint-plugin': 3.4.0_d518739ab3631bb2a5c22d38c3f5863a
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@8.19.0+typescript@4.7.4
-      '@typescript-eslint/parser': 3.4.0_eslint@8.19.0+typescript@4.7.4
-      '@typescript-eslint/typescript-estree': 3.4.0_typescript@4.7.4
+      '@rushstack/eslint-patch': 1.1.4
+      '@rushstack/eslint-plugin': 0.9.1_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/eslint-plugin-packlets': 0.4.1_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/eslint-plugin-security': 0.3.1_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/eslint-plugin': 5.20.0_14831e8fcbc01ef8ac4fe78054ab1bb3
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.20.0_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.7.4
       eslint: 8.19.0
-      eslint-plugin-promise: 4.2.1
-      eslint-plugin-react: 7.20.6_eslint@8.19.0
+      eslint-plugin-promise: 6.0.0_eslint@8.19.0
+      eslint-plugin-react: 7.27.1_eslint@8.19.0
       eslint-plugin-tsdoc: 0.2.16
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@rushstack/eslint-patch/1.0.6:
-    resolution: {integrity: sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==}
+  /@rushstack/eslint-patch/1.1.4:
+    resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
     dev: false
 
-  /@rushstack/eslint-plugin-packlets/0.2.2_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-8kKs5fq9Mm9sP4W7ETbp48eH6iECfXDKP1mdg2iBPl8CaZZHMzVYC2vQSSSOOMv+OV23LreRFWV0LlllEDuD3Q==}
+  /@rushstack/eslint-plugin-packlets/0.4.1_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-A+mb+45fAUV6SRRlRy5EXrZAHNTnvOO3ONxw0hmRDcvyPAJwoX0ClkKQriz56QQE5SL4sPxhYoqbkoKbBmsxcA==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@rushstack/eslint-plugin-security/0.1.4_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-AiNUS5H4/RvyNI9FDKdd4ya3PovjpPVU9Pr7He1JPvqLHOCT8P9n5YpRHjxx0ftD77mDLT5HrcOKjxTW7BZQHg==}
+  /@rushstack/eslint-plugin-security/0.3.1_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-LOBJj7SLPkeonBq2CD9cKqujwgc84YXJP18UXmGYl8xE3OM+Fwgnav7GzsakyvkeWJwq7EtpZjjSW8DTpwfA4w==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@rushstack/eslint-plugin/0.7.3_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-8+AqxybpcJJuxn0+fsWwMIMj2g2tLfPrbOyhEi+Rozh36eTmgGXF45qh8bHE1gicsX4yGDj2ob1P62oQV6hs3g==}
+  /@rushstack/eslint-plugin/0.9.1_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-iMfRyk9FE1xdhuenIYwDEjJ67u7ygeFw/XBGJC2j4GHclznHWRfSGiwTeYZ66H74h7NkVTuTp8RYw/x2iDblOA==}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@rushstack/tree-pattern': 0.2.1
-      '@typescript-eslint/experimental-utils': 3.10.1_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
       eslint: 8.19.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@rushstack/tree-pattern/0.2.1:
-    resolution: {integrity: sha512-ZRPQdV0LxUY/HRIvVKNz3Sb/qbklSthL2pY0qkNoycXKcXbCgXEP3TxL+i1/tW9g1jqft4o+pl9wx12Q6Uc0Xw==}
+  /@rushstack/tree-pattern/0.2.4:
+    resolution: {integrity: sha512-H8i0OinWsdKM1TKEKPeRRTw85e+/7AIFpxm7q1blceZJhuxRBjCGAUZvQXZK4CMLx75xPqh/h1t5WHwFmElAPA==}
     dev: false
 
   /@sinonjs/commons/1.8.3:
@@ -2064,10 +2038,6 @@ packages:
     dependencies:
       '@types/eslint': 8.4.3
       '@types/estree': 0.0.51
-    dev: false
-
-  /@types/eslint-visitor-keys/1.0.0:
-    resolution: {integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==}
     dev: false
 
   /@types/eslint/8.4.3:
@@ -2207,22 +2177,25 @@ packages:
     resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin/3.4.0_d518739ab3631bb2a5c22d38c3f5863a:
-    resolution: {integrity: sha512-wfkpiqaEVhZIuQRmudDszc01jC/YR7gMSxa6ulhggAe/Hs0KVIuo9wzvFiDbG3JD5pRFQoqnf4m7REDsUvBnMQ==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/eslint-plugin/5.20.0_14831e8fcbc01ef8ac4fe78054ab1bb3:
+    resolution: {integrity: sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^3.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.4.0_eslint@8.19.0+typescript@4.7.4
-      '@typescript-eslint/parser': 3.4.0_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.20.0_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/type-utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
+      '@typescript-eslint/utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
       debug: 4.3.4
       eslint: 8.19.0
       functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
       tsutils: 3.21.0_typescript@4.7.4
@@ -2258,54 +2231,34 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils/3.10.1_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/experimental-utils/5.20.0_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-w5qtx2Wr9x13Dp/3ic9iGOGmVXK5gMwyc8rwVgZU46K9WTjPZSyPvdER9Ycy+B5lNHvoz+z2muWhUvlTpQeu+g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/typescript-estree': 3.10.1_typescript@4.7.4
+      '@typescript-eslint/utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
       eslint: 8.19.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/experimental-utils/3.4.0_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-rHPOjL43lOH1Opte4+dhC0a/+ks+8gOBwxXnyrZ/K4OTAChpSjP76fbI8Cglj7V5GouwVAGaK+xVwzqTyE/TPw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/parser/5.20.0_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/typescript-estree': 3.4.0_typescript@4.7.4
-      eslint: 8.19.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
-  /@typescript-eslint/parser/3.4.0_eslint@8.19.0+typescript@4.7.4:
-    resolution: {integrity: sha512-ZUGI/de44L5x87uX5zM14UYcbn79HSXUR+kzcqU42gH0AgpdB/TjuJy3m4ezI7Q/jk3wTQd755mxSDLhQP79KA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.4.0_eslint@8.19.0+typescript@4.7.4
-      '@typescript-eslint/typescript-estree': 3.4.0_typescript@4.7.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.7.4
+      debug: 4.3.4
       eslint: 8.19.0
-      eslint-visitor-keys: 1.3.0
       typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
@@ -2331,12 +2284,39 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/scope-manager/5.20.0:
+    resolution: {integrity: sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/visitor-keys': 5.20.0
+    dev: false
+
   /@typescript-eslint/scope-manager/5.30.5:
     resolution: {integrity: sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.30.5
       '@typescript-eslint/visitor-keys': 5.30.5
+    dev: false
+
+  /@typescript-eslint/type-utils/5.20.0_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.20.0_eslint@8.19.0+typescript@4.7.4
+      debug: 4.3.4
+      eslint: 8.19.0
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@typescript-eslint/type-utils/5.30.5_eslint@8.19.0+typescript@4.7.4:
@@ -2358,9 +2338,9 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types/3.10.1:
-    resolution: {integrity: sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+  /@typescript-eslint/types/5.20.0:
+    resolution: {integrity: sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
   /@typescript-eslint/types/5.30.5:
@@ -2368,42 +2348,20 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/3.10.1_typescript@4.7.4:
-    resolution: {integrity: sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/typescript-estree/5.20.0_typescript@4.7.4:
+    resolution: {integrity: sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 3.10.1
-      '@typescript-eslint/visitor-keys': 3.10.1
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/visitor-keys': 5.20.0
       debug: 4.3.4
-      glob: 7.2.3
+      globby: 11.1.0
       is-glob: 4.0.3
-      lodash: 4.17.21
-      semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/typescript-estree/3.4.0_typescript@4.7.4:
-    resolution: {integrity: sha512-zKwLiybtt4uJb4mkG5q2t6+W7BuYx2IISiDNV+IY68VfoGwErDx/RfVI7SWL4gnZ2t1A1ytQQwZ+YOJbHHJ2rw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-      eslint-visitor-keys: 1.3.0
-      glob: 7.2.3
-      is-glob: 4.0.3
-      lodash: 4.17.21
       semver: 7.3.7
       tsutils: 3.21.0_typescript@4.7.4
       typescript: 4.7.4
@@ -2432,6 +2390,24 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/utils/5.20.0_eslint@8.19.0+typescript@4.7.4:
+    resolution: {integrity: sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.7.4
+      eslint: 8.19.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.19.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/utils/5.30.5_eslint@8.19.0+typescript@4.7.4:
     resolution: {integrity: sha512-o4SSUH9IkuA7AYIfAvatldovurqTAHrfzPApOZvdUq01hHojZojCFXx06D/aFpKCgWbMPRdJBWAC3sWp3itwTA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2450,11 +2426,12 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/visitor-keys/3.10.1:
-    resolution: {integrity: sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+  /@typescript-eslint/visitor-keys/5.20.0:
+    resolution: {integrity: sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      eslint-visitor-keys: 1.3.0
+      '@typescript-eslint/types': 5.20.0
+      eslint-visitor-keys: 3.3.0
     dev: false
 
   /@typescript-eslint/visitor-keys/5.30.5:
@@ -3896,28 +3873,35 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: false
 
-  /eslint-plugin-promise/4.2.1:
-    resolution: {integrity: sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==}
-    engines: {node: '>=6'}
+  /eslint-plugin-promise/6.0.0_eslint@8.19.0:
+    resolution: {integrity: sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      eslint: 8.19.0
     dev: false
 
-  /eslint-plugin-react/7.20.6_eslint@8.19.0:
-    resolution: {integrity: sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==}
+  /eslint-plugin-react/7.27.1_eslint@8.19.0:
+    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
     dependencies:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
       eslint: 8.19.0
-      has: 1.0.3
+      estraverse: 5.3.0
       jsx-ast-utils: 2.4.1
+      minimatch: 3.1.2
       object.entries: 1.1.5
       object.fromentries: 2.0.5
+      object.hasown: 1.1.1
       object.values: 1.1.5
       prop-types: 15.8.1
-      resolve: 1.22.1
+      resolve: 2.0.0-next.4
+      semver: 6.3.0
       string.prototype.matchall: 4.0.7
     dev: false
 
@@ -3944,13 +3928,6 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /eslint-utils/2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-    dev: false
-
   /eslint-utils/3.0.0_eslint@8.19.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -3959,11 +3936,6 @@ packages:
     dependencies:
       eslint: 8.19.0
       eslint-visitor-keys: 2.1.0
-    dev: false
-
-  /eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: false
 
   /eslint-visitor-keys/2.1.0:
@@ -6407,6 +6379,13 @@ packages:
       es-abstract: 1.20.1
     dev: false
 
+  /object.hasown/1.1.1:
+    resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==}
+    dependencies:
+      define-properties: 1.1.4
+      es-abstract: 1.20.1
+    dev: false
+
   /object.pick/1.3.0:
     resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
     engines: {node: '>=0.10.0'}
@@ -6917,6 +6896,15 @@ packages:
 
   /resolve/1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.9.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: false
+
+  /resolve/2.0.0-next.4:
+    resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
       is-core-module: 2.9.0
@@ -7458,15 +7446,6 @@ packages:
 
   /swagger-ui-dist/4.12.0:
     resolution: {integrity: sha512-B0Iy2ueXtbByE6OOyHTi3lFQkpPi/L7kFOKFeKTr44za7dJIELa9kzaca6GkndCgpK1QTjArnoXG+aUy0XQp1w==}
-    dev: false
-
-  /swagger-ui-express/4.4.0:
-    resolution: {integrity: sha512-1CzRkHG386VQMVZK406jcpgnW2a9A5A/NiAjKhsFTQqUBWRF+uGbXTU/mA7WSV3mTzyOQDvjBdWP/c2qd5lqKw==}
-    engines: {node: '>= v0.10.32'}
-    peerDependencies:
-      express: '>=4.0.0'
-    dependencies:
-      swagger-ui-dist: 4.12.0
     dev: false
 
   /swagger-ui-express/4.5.0:
@@ -8407,12 +8386,12 @@ packages:
     dev: false
 
   file:projects/ssi-did.tgz_ts-node@10.8.1:
-    resolution: {integrity: sha512-oZdstXdhAXJcXd+55tXSwJZegO1vggoHZIVS08aqemtqPdv0y9sL6QwL8pe7bYMYYCkXqwpGsTk+1OWrk8MrHg==, tarball: file:projects/ssi-did.tgz}
+    resolution: {integrity: sha512-kZHVzuKStjDVAhjlR+ZwM/EH4P4KWJLvNZJ/iW4W+ohP5vNeB/zHSeaKCJtBArDwNIVngpSYqG/XjVwc8vOR2A==, tarball: file:projects/ssi-did.tgz}
     id: file:projects/ssi-did.tgz
     name: '@rush-temp/ssi-did'
     version: 0.0.0
     dependencies:
-      '@rushstack/eslint-config': 2.3.4_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/eslint-config': 2.6.2_eslint@8.19.0+typescript@4.7.4
       '@spruceid/didkit-wasm-node': 0.2.1
       '@trust/keyto': 1.0.1
       '@types/jest': 27.5.2
@@ -8437,7 +8416,7 @@ packages:
     dev: false
 
   file:projects/ssi-vc-api.tgz_babel-jest@26.6.3:
-    resolution: {integrity: sha512-Eg8JMtIHCR8YPo1MJA9Eyf6nt+XWytWhCV0M3aSYhTqj+DP0G69PkPt3jvYU9AFhUnS/oshjclWIrQWrX0innQ==, tarball: file:projects/ssi-vc-api.tgz}
+    resolution: {integrity: sha512-/zxEe8Fn2B+rZEZc2muoC8n+SN8gtT2LSNaScKCnhHJFCh9beihuBI3FyUzA00QYq+tSRxg3qXT5chvQYUbPpg==, tarball: file:projects/ssi-vc-api.tgz}
     id: file:projects/ssi-vc-api.tgz
     name: '@rush-temp/ssi-vc-api'
     version: 0.0.0
@@ -8453,7 +8432,7 @@ packages:
       '@nestjs/swagger': 5.1.5_ce4055f8a70424510229f2128b9d2f34
       '@nestjs/testing': 8.4.7_c1bddf0102e0d68dc342d4afcbe21907
       '@nestjs/typeorm': 8.0.4_4967a077601f378d566b47f3ee68696d
-      '@rushstack/eslint-config': 2.3.4_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/eslint-config': 2.6.2_eslint@8.19.0+typescript@4.7.4
       '@sphereon/pex': 1.1.2
       '@sphereon/pex-models': 1.1.0
       '@spruceid/didkit-wasm-node': 0.2.1
@@ -8526,11 +8505,11 @@ packages:
     dev: false
 
   file:projects/w3c-ccg-webkms.tgz:
-    resolution: {integrity: sha512-zK10j8sR9Qxhk6JFLslirqCe8JM+I1jUGjDIF2fw4iJJrShiryCfEpa3xeikdpCoDllrfb/hXtZ03t9B6INrjA==, tarball: file:projects/w3c-ccg-webkms.tgz}
+    resolution: {integrity: sha512-p4t108NORJ9WeG7YLNcfHHkT29vPGQTV03ORO01N1mD3EhvY25ez9ffEXoAqM4hVbCdVIGlVfzAQLZMF+tDrhA==, tarball: file:projects/w3c-ccg-webkms.tgz}
     name: '@rush-temp/w3c-ccg-webkms'
     version: 0.0.0
     dependencies:
-      '@rushstack/eslint-config': 2.3.4_eslint@8.19.0+typescript@4.7.4
+      '@rushstack/eslint-config': 2.6.2_eslint@8.19.0+typescript@4.7.4
       eslint: 8.19.0
       ethers: 5.5.1
       jose: 4.8.3

--- a/libraries/did/package.json
+++ b/libraries/did/package.json
@@ -25,7 +25,7 @@
     "@spruceid/didkit-wasm-node": "~0.2.0"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "~2.3.0",
+    "@rushstack/eslint-config": "~2.6.0",
     "@types/jest": "^27.0.0",
     "babel-jest": "26.6.3",
     "eslint": "^8.0.0",

--- a/libraries/webkms/package.json
+++ b/libraries/webkms/package.json
@@ -21,7 +21,7 @@
     "jose": "^4.0.0"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "~2.3.0",
+    "@rushstack/eslint-config": "~2.6.0",
     "eslint": "^8.0.0",
     "typescript": "^4.0.0"
   },


### PR DESCRIPTION
This PR solves incompatibility issues of @rushstack/eslint-config v2.3 with eslint v8