### PR TITLE
fix: fixing CI broken 

### DIFF
--- a/apps/credential-from-input-descriptor/Dockerfile
+++ b/apps/credential-from-input-descriptor/Dockerfile
@@ -12,6 +12,7 @@ COPY apps/vc-api/package.json apps/vc-api/package.json
 COPY libraries/did/package.json libraries/did/package.json
 COPY libraries/webkms/package.json libraries/webkms/package.json
 COPY apps/credential-from-input-descriptor/package.json apps/credential-from-input-descriptor/package.json
+COPY tests/e2e/package.json tests/e2e/package.json
 
 RUN node common/scripts/install-run-rush.js install
 


### PR DESCRIPTION
This PR fixes CI broken after adding the `tests/e2e` project. The reason is that the `test/e2e/package.json` file is not copied when the "Converter" image is built.