### PR TITLE
fix: adding missing version prefix in url generated by API endpoints

### DIFF
--- a/apps/vc-api/src/setup.ts
+++ b/apps/vc-api/src/setup.ts
@@ -21,7 +21,7 @@ import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 export const API_DEFAULT_VERSION_PREFIX: string = '/v1';
-const API_DEFAULT_VERSION: string = API_DEFAULT_VERSION_PREFIX.replace(/^\/v/, '');
+export const API_DEFAULT_VERSION: string = API_DEFAULT_VERSION_PREFIX.replace(/^\/v/, '');
 
 async function setupApp(): Promise<INestApplication> {
   const app = await NestFactory.create(AppModule);

--- a/apps/vc-api/src/setup.ts
+++ b/apps/vc-api/src/setup.ts
@@ -20,8 +20,8 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
-export const API_DEFAULT_VERSION_PREFIX: string = '/v1';
-export const API_DEFAULT_VERSION: string = API_DEFAULT_VERSION_PREFIX.replace(/^\/v/, '');
+export const API_DEFAULT_VERSION: string = '1';
+export const API_DEFAULT_VERSION_PREFIX: string = `/v${API_DEFAULT_VERSION}`;
 
 async function setupApp(): Promise<INestApplication> {
   const app = await NestFactory.create(AppModule);

--- a/apps/vc-api/src/setup.ts
+++ b/apps/vc-api/src/setup.ts
@@ -20,13 +20,16 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
+export const API_DEFAULT_VERSION_PREFIX: string = '/v1';
+const API_DEFAULT_VERSION: string = API_DEFAULT_VERSION_PREFIX.replace(/^\/v/, '');
+
 async function setupApp(): Promise<INestApplication> {
   const app = await NestFactory.create(AppModule);
   app.enableCors({ origin: true });
   app.useGlobalPipes(new ValidationPipe());
   app.enableVersioning({
     type: VersioningType.URI,
-    defaultVersion: ['1']
+    defaultVersion: [API_DEFAULT_VERSION]
   });
   return app;
 }

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -76,7 +76,7 @@ export class ExchangeService {
         processingInProgress: false
       };
     }
-    const baseWithControllerPath = `${baseUrl}/vc-api`;
+    const baseWithControllerPath = `${baseUrl}/v1/vc-api`;
     const transaction = exchange.start(baseWithControllerPath);
     await this.transactionRepository.save(transaction);
     return {

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -31,6 +31,7 @@ import { TransactionDto } from './dtos/transaction.dto';
 import { ReviewResult, SubmissionReviewDto } from './dtos/submission-review.dto';
 import { VpSubmissionVerifierService } from './vp-submission-verifier.service';
 import { validate } from 'class-validator';
+import { API_DEFAULT_VERSION_PREFIX } from '../../setup';
 
 @Injectable()
 export class ExchangeService {
@@ -76,7 +77,7 @@ export class ExchangeService {
         processingInProgress: false
       };
     }
-    const baseWithControllerPath = `${baseUrl}/v1/vc-api`;
+    const baseWithControllerPath = `${baseUrl}${API_DEFAULT_VERSION_PREFIX}/vc-api`;
     const transaction = exchange.start(baseWithControllerPath);
     await this.transactionRepository.save(transaction);
     return {

--- a/apps/vc-api/test/app.e2e-spec.ts
+++ b/apps/vc-api/test/app.e2e-spec.ts
@@ -27,7 +27,7 @@ import { vcApiSuite } from './vc-api/credentials/vc-api.e2e-suite';
 import { keySuite } from './key/key.e2e-suite';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ExchangeEntity } from '../src/vc-api/exchanges/entities/exchange.entity';
-import { API_DEFAULT_VERSION_PREFIX } from '../src/setup';
+import { API_DEFAULT_VERSION, API_DEFAULT_VERSION_PREFIX } from '../src/setup';
 
 // Increasing timeout for debugging
 // Should only affect this file https://jestjs.io/docs/jest-object#jestsettimeouttimeout
@@ -47,7 +47,7 @@ describe('App (e2e)', () => {
     app.useGlobalPipes(new ValidationPipe()); // https://github.com/nestjs/nest/issues/5264
     app.enableVersioning({
       type: VersioningType.URI,
-      defaultVersion: ['1']
+      defaultVersion: [API_DEFAULT_VERSION]
     });
     await app.init();
     walletClient = new WalletClient(app);

--- a/apps/vc-api/test/app.e2e-spec.ts
+++ b/apps/vc-api/test/app.e2e-spec.ts
@@ -27,6 +27,7 @@ import { vcApiSuite } from './vc-api/credentials/vc-api.e2e-suite';
 import { keySuite } from './key/key.e2e-suite';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ExchangeEntity } from '../src/vc-api/exchanges/entities/exchange.entity';
+import { API_DEFAULT_VERSION_PREFIX } from '../src/setup';
 
 // Increasing timeout for debugging
 // Should only affect this file https://jestjs.io/docs/jest-object#jestsettimeouttimeout
@@ -34,7 +35,7 @@ jest.setTimeout(300 * 1000);
 
 export let app: INestApplication;
 export let walletClient: WalletClient;
-export const vcApiBaseUrl = '/v1/vc-api';
+export const vcApiBaseUrl = `${API_DEFAULT_VERSION_PREFIX}/vc-api`;
 
 describe('App (e2e)', () => {
   beforeEach(async () => {

--- a/apps/vc-api/test/app.e2e-spec.ts
+++ b/apps/vc-api/test/app.e2e-spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
 import { AppModule } from '../src/app.module';
 import { WalletClient } from './wallet-client';
 import { didSuite } from './did/did.e2e-suite';
@@ -34,7 +34,7 @@ jest.setTimeout(300 * 1000);
 
 export let app: INestApplication;
 export let walletClient: WalletClient;
-export const vcApiBaseUrl = '/vc-api';
+export const vcApiBaseUrl = '/v1/vc-api';
 
 describe('App (e2e)', () => {
   beforeEach(async () => {
@@ -44,6 +44,10 @@ describe('App (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe()); // https://github.com/nestjs/nest/issues/5264
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: ['1']
+    });
     await app.init();
     walletClient = new WalletClient(app);
 

--- a/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
@@ -19,8 +19,7 @@ import * as request from 'supertest';
 import { CredentialDto } from '../../../src/vc-api/credentials/dtos/credential.dto';
 import { IssueOptionsDto } from '../../../src/vc-api/credentials/dtos/issue-options.dto';
 import { app, walletClient } from '../../app.e2e-spec';
-
-const API_VERSION = 'v1';
+import { API_DEFAULT_VERSION_PREFIX } from '../../../src/setup';
 
 export const vcApiSuite = () => {
   it('should issue using a generated did:key', async () => {
@@ -37,7 +36,7 @@ export const vcApiSuite = () => {
     };
     const options: IssueOptionsDto = {};
     const postResponse = await request(app.getHttpServer())
-      .post(`/${API_VERSION}/vc-api/credentials/issue`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/credentials/issue`)
       .send({ credential, options })
       .expect(201);
     expect(postResponse.body).toBeDefined();

--- a/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
+++ b/apps/vc-api/test/vc-api/credentials/vc-api.e2e-suite.ts
@@ -20,6 +20,8 @@ import { CredentialDto } from '../../../src/vc-api/credentials/dtos/credential.d
 import { IssueOptionsDto } from '../../../src/vc-api/credentials/dtos/issue-options.dto';
 import { app, walletClient } from '../../app.e2e-spec';
 
+const API_VERSION = 'v1';
+
 export const vcApiSuite = () => {
   it('should issue using a generated did:key', async () => {
     const didDoc = await walletClient.createDID('key');
@@ -35,7 +37,7 @@ export const vcApiSuite = () => {
     };
     const options: IssueOptionsDto = {};
     const postResponse = await request(app.getHttpServer())
-      .post('/vc-api/credentials/issue')
+      .post(`/${API_VERSION}/vc-api/credentials/issue`)
       .send({ credential, options })
       .expect(201);
     expect(postResponse.body).toBeDefined();

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -31,8 +31,7 @@ import { IPresentationDefinition } from '@sphereon/pex';
 import { PresentationDto } from '../src/vc-api/credentials/dtos/presentation.dto';
 import { KeyPairDto } from '../src/key/dtos/key-pair.dto';
 import { KeyDescriptionDto } from 'src/key/dtos/key-description.dto';
-
-const API_VERSION = 'v1';
+import { API_DEFAULT_VERSION_PREFIX } from '../src/setup';
 
 /**
  * A wallet client for e2e tests
@@ -46,7 +45,7 @@ export class WalletClient {
 
   async exportKey(keyId: string): Promise<KeyPairDto> {
     const getResponse = await request(this.#app.getHttpServer())
-      .get(`/${API_VERSION}/key/${keyId}`)
+      .get(`${API_DEFAULT_VERSION_PREFIX}/key/${keyId}`)
       .expect(200);
     expect(getResponse.body).toHaveProperty('privateKey');
     expect(getResponse.body).toHaveProperty('publicKey');
@@ -55,7 +54,7 @@ export class WalletClient {
 
   async importKey(keyPair: KeyPairDto): Promise<KeyDescriptionDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/key`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/key`)
       .send(keyPair)
       .expect(201);
     expect(postResponse.body).toHaveProperty('keyId');
@@ -64,7 +63,7 @@ export class WalletClient {
 
   async createDID(requestedMethod: string, keyId?: string): Promise<DIDDocument> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/did`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/did`)
       .send({ method: requestedMethod, keyId })
       .expect(201);
     expect(postResponse.body).toHaveProperty('id');
@@ -75,7 +74,7 @@ export class WalletClient {
     expect(createdMethod).toEqual(requestedMethod);
 
     const getResponse = await request(this.#app.getHttpServer())
-      .get(`/${API_VERSION}/did/${newDID}`)
+      .get(`${API_DEFAULT_VERSION_PREFIX}/did/${newDID}`)
       .expect(200);
     expect(getResponse.body).toHaveProperty('verificationMethod');
     expect(postResponse.body['verificationMethod']).toMatchObject(getResponse.body['verificationMethod']);
@@ -84,7 +83,7 @@ export class WalletClient {
 
   async issueVC(issueCredentialDto: IssueCredentialDto): Promise<VerifiableCredentialDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/vc-api/credentials/issue`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/credentials/issue`)
       .send(issueCredentialDto)
       .expect(201);
     return postResponse.body;
@@ -95,7 +94,7 @@ export class WalletClient {
     credentials: VerifiableCredentialDto[]
   ): Promise<PresentationDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/vc-api/presentations/from`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/presentations/from`)
       .send({ presentationDefinition, credentials })
       .expect(201);
     return postResponse.body;
@@ -103,7 +102,7 @@ export class WalletClient {
 
   async provePresentation(provePresentationDto: ProvePresentationDto): Promise<VerifiablePresentationDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/vc-api/presentations/prove`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/presentations/prove`)
       .send(provePresentationDto)
       .expect(201);
     return postResponse.body;
@@ -154,7 +153,7 @@ export class WalletClient {
    */
   async getExchangeTransaction(exchangeId: string, transactionId: string) {
     const continueExchangeResponse = await request(this.#app.getHttpServer())
-      .get(`/${API_VERSION}/vc-api/exchanges/${exchangeId}/${transactionId}`)
+      .get(`${API_DEFAULT_VERSION_PREFIX}/vc-api/exchanges/${exchangeId}/${transactionId}`)
       .expect(200);
     expect(continueExchangeResponse.body.errors).toHaveLength(0);
     expect(continueExchangeResponse.body.transaction).toBeDefined();
@@ -170,7 +169,7 @@ export class WalletClient {
     submissionReviewDto: SubmissionReviewDto
   ) {
     const continueExchangeResponse = await request(this.#app.getHttpServer())
-      .post(`/${API_VERSION}/vc-api/exchanges/${exchangeId}/${transactionId}/review`)
+      .post(`${API_DEFAULT_VERSION_PREFIX}/vc-api/exchanges/${exchangeId}/${transactionId}/review`)
       .send(submissionReviewDto)
       .expect(201);
     return continueExchangeResponse?.body;

--- a/apps/vc-api/test/wallet-client.ts
+++ b/apps/vc-api/test/wallet-client.ts
@@ -32,6 +32,8 @@ import { PresentationDto } from '../src/vc-api/credentials/dtos/presentation.dto
 import { KeyPairDto } from '../src/key/dtos/key-pair.dto';
 import { KeyDescriptionDto } from 'src/key/dtos/key-description.dto';
 
+const API_VERSION = 'v1';
+
 /**
  * A wallet client for e2e tests
  */
@@ -44,7 +46,7 @@ export class WalletClient {
 
   async exportKey(keyId: string): Promise<KeyPairDto> {
     const getResponse = await request(this.#app.getHttpServer())
-      .get(`/key/${keyId}`)
+      .get(`/${API_VERSION}/key/${keyId}`)
       .expect(200);
     expect(getResponse.body).toHaveProperty('privateKey');
     expect(getResponse.body).toHaveProperty('publicKey');
@@ -53,7 +55,7 @@ export class WalletClient {
 
   async importKey(keyPair: KeyPairDto): Promise<KeyDescriptionDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post('/key')
+      .post(`/${API_VERSION}/key`)
       .send(keyPair)
       .expect(201);
     expect(postResponse.body).toHaveProperty('keyId');
@@ -62,7 +64,7 @@ export class WalletClient {
 
   async createDID(requestedMethod: string, keyId?: string): Promise<DIDDocument> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post('/did')
+      .post(`/${API_VERSION}/did`)
       .send({ method: requestedMethod, keyId })
       .expect(201);
     expect(postResponse.body).toHaveProperty('id');
@@ -73,7 +75,7 @@ export class WalletClient {
     expect(createdMethod).toEqual(requestedMethod);
 
     const getResponse = await request(this.#app.getHttpServer())
-      .get(`/did/${newDID}`)
+      .get(`/${API_VERSION}/did/${newDID}`)
       .expect(200);
     expect(getResponse.body).toHaveProperty('verificationMethod');
     expect(postResponse.body['verificationMethod']).toMatchObject(getResponse.body['verificationMethod']);
@@ -82,7 +84,7 @@ export class WalletClient {
 
   async issueVC(issueCredentialDto: IssueCredentialDto): Promise<VerifiableCredentialDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post('/vc-api/credentials/issue')
+      .post(`/${API_VERSION}/vc-api/credentials/issue`)
       .send(issueCredentialDto)
       .expect(201);
     return postResponse.body;
@@ -93,7 +95,7 @@ export class WalletClient {
     credentials: VerifiableCredentialDto[]
   ): Promise<PresentationDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post('/vc-api/presentations/from')
+      .post(`/${API_VERSION}/vc-api/presentations/from`)
       .send({ presentationDefinition, credentials })
       .expect(201);
     return postResponse.body;
@@ -101,7 +103,7 @@ export class WalletClient {
 
   async provePresentation(provePresentationDto: ProvePresentationDto): Promise<VerifiablePresentationDto> {
     const postResponse = await request(this.#app.getHttpServer())
-      .post('/vc-api/presentations/prove')
+      .post(`/${API_VERSION}/vc-api/presentations/prove`)
       .send(provePresentationDto)
       .expect(201);
     return postResponse.body;
@@ -152,7 +154,7 @@ export class WalletClient {
    */
   async getExchangeTransaction(exchangeId: string, transactionId: string) {
     const continueExchangeResponse = await request(this.#app.getHttpServer())
-      .get(`/vc-api/exchanges/${exchangeId}/${transactionId}`)
+      .get(`/${API_VERSION}/vc-api/exchanges/${exchangeId}/${transactionId}`)
       .expect(200);
     expect(continueExchangeResponse.body.errors).toHaveLength(0);
     expect(continueExchangeResponse.body.transaction).toBeDefined();
@@ -168,7 +170,7 @@ export class WalletClient {
     submissionReviewDto: SubmissionReviewDto
   ) {
     const continueExchangeResponse = await request(this.#app.getHttpServer())
-      .post(`/vc-api/exchanges/${exchangeId}/${transactionId}/review`)
+      .post(`/${API_VERSION}/vc-api/exchanges/${exchangeId}/${transactionId}/review`)
       .send(submissionReviewDto)
       .expect(201);
     return continueExchangeResponse?.body;

--- a/devops/ssi-helm/values-dev.yaml
+++ b/devops/ssi-helm/values-dev.yaml
@@ -104,4 +104,4 @@ tolerations: []
 affinity: {}
 
 appValues:
-  BASE_URL: https://vc-api-dev.energyweb.org/v1
+  BASE_URL: https://vc-api-dev.energyweb.org

--- a/devops/ssi-helm/values-sandbox.yaml
+++ b/devops/ssi-helm/values-sandbox.yaml
@@ -104,4 +104,4 @@ tolerations: []
 affinity: {}
 
 appValues:
-  BASE_URL: https://vc-api-dev.energyweb.org/v1
+  BASE_URL: https://vc-api-dev.energyweb.org


### PR DESCRIPTION
This PR:
* fixes `.vpRequest.interact.service[0].serviceEndpoint` value in `/v1/vc-api/exchanges/{exchangeId}` response not having API version prefix
* fixes VC-API E2E tests application instance not having API version set to 1
* defines one `API_DEFAULT_VERSION_PREFIX` constant to define the default API version for both runtime and tests
* adjusts `BASE_URL` deployments settings to not include API path version prefix