### PR TITLE
feat: forbidding submission of VP by a non-matching DID

### DIFF
--- a/apps/vc-api/src/exception-filters/transaction-entity-exception.filter.ts
+++ b/apps/vc-api/src/exception-filters/transaction-entity-exception.filter.ts
@@ -17,17 +17,21 @@
 
 import { BaseExceptionFilter } from '@nestjs/core';
 import { TransactionEntityException } from '../vc-api/exchanges/entities/transaction.entity';
-import { ArgumentsHost, Catch, ForbiddenException } from '@nestjs/common';
+import { ArgumentsHost, Catch, ForbiddenException, Logger } from '@nestjs/common';
 
 @Catch(TransactionEntityException)
 export class TransactionEntityExceptionFilter extends BaseExceptionFilter {
+  private readonly logger: Logger = new Logger(TransactionEntityExceptionFilter.name, { timestamp: true });
+
   catch(exception: TransactionEntityException, host: ArgumentsHost): void {
     switch (exception.name) {
       case 'TransactionDidForbiddenException':
+        this.logger.warn(exception);
         super.catch(new ForbiddenException(exception.message), host);
         break;
 
       default:
+        this.logger.error(exception);
         super.catch(exception, host);
         break;
     }

--- a/apps/vc-api/src/exception-filters/transaction-entity-exception.filter.ts
+++ b/apps/vc-api/src/exception-filters/transaction-entity-exception.filter.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021, 2022 Energy Web Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { BaseExceptionFilter } from '@nestjs/core';
+import { TransactionEntityException } from '../vc-api/exchanges/entities/transaction.entity';
+import { ArgumentsHost, Catch, ForbiddenException } from '@nestjs/common';
+
+@Catch(TransactionEntityException)
+export class TransactionEntityExceptionFilter extends BaseExceptionFilter {
+  catch(exception: TransactionEntityException, host: ArgumentsHost): void {
+    switch (exception.name) {
+      case 'TransactionDidForbiddenException':
+        super.catch(new ForbiddenException(exception.message), host);
+        break;
+
+      default:
+        super.catch(exception, host);
+        break;
+    }
+  }
+}

--- a/apps/vc-api/src/setup.ts
+++ b/apps/vc-api/src/setup.ts
@@ -19,6 +19,7 @@ import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { TransactionEntityExceptionFilter } from './exception-filters/transaction-entity-exception.filter';
 
 export const API_DEFAULT_VERSION: string = '1';
 export const API_DEFAULT_VERSION_PREFIX: string = `/v${API_DEFAULT_VERSION}`;
@@ -27,6 +28,7 @@ async function setupApp(): Promise<INestApplication> {
   const app = await NestFactory.create(AppModule);
   app.enableCors({ origin: true });
   app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalFilters(new TransactionEntityExceptionFilter(app.getHttpAdapter()));
   app.enableVersioning({
     type: VersioningType.URI,
     defaultVersion: [API_DEFAULT_VERSION]

--- a/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -134,8 +134,8 @@ export class TransactionEntity {
     }
 
     const service = this.vpRequest.interact.service[0]; // TODO: Not sure how to handle multiple interaction services
-    if (service.type == VpRequestInteractServiceType.mediatedPresentation) {
-      if (this.presentationReview.reviewStatus == PresentationReviewStatus.pendingSubmission) {
+    if (service.type === VpRequestInteractServiceType.mediatedPresentation) {
+      if (this.presentationReview.reviewStatus === PresentationReviewStatus.pendingSubmission) {
         // TODO: should we allow overwrite of a previous submitted submission?
         if (!this.presentationSubmission) {
           this.presentationSubmission = new PresentationSubmissionEntity(presentation, verificationResult);
@@ -155,8 +155,8 @@ export class TransactionEntity {
         };
       }
       if (
-        this.presentationReview.reviewStatus == PresentationReviewStatus.approved ||
-        this.presentationReview.reviewStatus == PresentationReviewStatus.rejected
+        this.presentationReview.reviewStatus === PresentationReviewStatus.approved ||
+        this.presentationReview.reviewStatus === PresentationReviewStatus.rejected
       ) {
         return {
           response: {
@@ -168,7 +168,7 @@ export class TransactionEntity {
         };
       }
     }
-    if (service.type == VpRequestInteractServiceType.unmediatedPresentation) {
+    if (service.type === VpRequestInteractServiceType.unmediatedPresentation) {
       this.presentationSubmission = new PresentationSubmissionEntity(presentation, verificationResult);
       return {
         response: {

--- a/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -26,7 +26,19 @@ import { VpRequestEntity } from './vp-request.entity';
 import { CallbackConfiguration } from '../types/callback-configuration';
 import { PresentationSubmissionEntity } from './presentation-submission.entity';
 import { SubmissionVerifier } from '../types/submission-verifier';
-import { ForbiddenException } from '@nestjs/common';
+
+export class TransactionEntityException extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.initName();
+  }
+
+  public initName(): void {
+    this.name = this.constructor.name;
+  }
+}
+
+export class TransactionDidForbiddenException extends TransactionEntityException {}
 
 /**
  * A TypeOrm entity representing an exchange transaction
@@ -117,7 +129,9 @@ export class TransactionEntity {
     verifier: SubmissionVerifier
   ): Promise<{ response: ExchangeResponseDto; callback: CallbackConfiguration[] }> {
     if (this.presentationSubmission && this.presentationSubmission.vp.holder !== presentation.holder) {
-      throw new ForbiddenException('DID does not match the DID that initially submitted the presentation');
+      throw new TransactionDidForbiddenException(
+        'DID does not match the DID that initially submitted the presentation'
+      );
     }
 
     const verificationResult = await verifier.verifyVpRequestSubmission(presentation, this.vpRequest);

--- a/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
+++ b/apps/vc-api/src/vc-api/exchanges/entities/transaction.entity.ts
@@ -26,6 +26,7 @@ import { VpRequestEntity } from './vp-request.entity';
 import { CallbackConfiguration } from '../types/callback-configuration';
 import { PresentationSubmissionEntity } from './presentation-submission.entity';
 import { SubmissionVerifier } from '../types/submission-verifier';
+import { ForbiddenException } from '@nestjs/common';
 
 /**
  * A TypeOrm entity representing an exchange transaction
@@ -115,6 +116,10 @@ export class TransactionEntity {
     presentation: VerifiablePresentation,
     verifier: SubmissionVerifier
   ): Promise<{ response: ExchangeResponseDto; callback: CallbackConfiguration[] }> {
+    if (this.presentationSubmission && this.presentationSubmission.vp.holder !== presentation.holder) {
+      throw new ForbiddenException('DID does not match the DID that initially submitted the presentation');
+    }
+
     const verificationResult = await verifier.verifyVpRequestSubmission(presentation, this.vpRequest);
     const errors = verificationResult.errors;
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ConflictException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -25,7 +25,7 @@ import { ExchangeEntity } from './entities/exchange.entity';
 import { ExchangeResponseDto } from './dtos/exchange-response.dto';
 import { VpRequestDto } from './dtos/vp-request.dto';
 import { ExchangeDefinitionDto } from './dtos/exchange-definition.dto';
-import { TransactionDidForbiddenException, TransactionEntity } from './entities/transaction.entity';
+import { TransactionEntity } from './entities/transaction.entity';
 import { ConfigService } from '@nestjs/config';
 import { TransactionDto } from './dtos/transaction.dto';
 import { ReviewResult, SubmissionReviewDto } from './dtos/submission-review.dto';
@@ -107,15 +107,10 @@ export class ExchangeService {
     }
     const transaction = transactionQuery.transaction;
 
-    const { response, callback } = await transaction
-      .processPresentation(verifiablePresentation, this.vpSubmissionVerifierService)
-      .catch((err) => {
-        if (err instanceof TransactionDidForbiddenException) {
-          throw new ForbiddenException(err.message);
-        }
-
-        throw err;
-      });
+    const { response, callback } = await transaction.processPresentation(
+      verifiablePresentation,
+      this.vpSubmissionVerifierService
+    );
     await this.transactionRepository.save(transaction);
     const body = TransactionDto.toDto(transaction);
     // TODO: react to validation errors

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -106,6 +106,13 @@ export class ExchangeService {
       };
     }
     const transaction = transactionQuery.transaction;
+
+    if (
+      transaction.presentationSubmission &&
+      transaction.presentationSubmission.vp.holder !== verifiablePresentation.holder
+    ) {
+      throw new ForbiddenException('DID does not match the DID that initially submitted the presentation');
+    }
 
     const { response, callback } = await transaction.processPresentation(
       verifiablePresentation,

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ConflictException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -106,13 +106,6 @@ export class ExchangeService {
       };
     }
     const transaction = transactionQuery.transaction;
-
-    if (
-      transaction.presentationSubmission &&
-      transaction.presentationSubmission.vp.holder !== verifiablePresentation.holder
-    ) {
-      throw new ForbiddenException('DID does not match the DID that initially submitted the presentation');
-    }
 
     const { response, callback } = await transaction.processPresentation(
       verifiablePresentation,

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -25,7 +25,7 @@ import { ExchangeEntity } from './entities/exchange.entity';
 import { ExchangeResponseDto } from './dtos/exchange-response.dto';
 import { VpRequestDto } from './dtos/vp-request.dto';
 import { ExchangeDefinitionDto } from './dtos/exchange-definition.dto';
-import { TransactionEntity } from './entities/transaction.entity';
+import { TransactionDidForbiddenException, TransactionEntity } from './entities/transaction.entity';
 import { ConfigService } from '@nestjs/config';
 import { TransactionDto } from './dtos/transaction.dto';
 import { ReviewResult, SubmissionReviewDto } from './dtos/submission-review.dto';
@@ -107,10 +107,15 @@ export class ExchangeService {
     }
     const transaction = transactionQuery.transaction;
 
-    const { response, callback } = await transaction.processPresentation(
-      verifiablePresentation,
-      this.vpSubmissionVerifierService
-    );
+    const { response, callback } = await transaction
+      .processPresentation(verifiablePresentation, this.vpSubmissionVerifierService)
+      .catch((err) => {
+        if (err instanceof TransactionDidForbiddenException) {
+          throw new ForbiddenException(err.message);
+        }
+
+        throw err;
+      });
     await this.transactionRepository.save(transaction);
     const body = TransactionDto.toDto(transaction);
     // TODO: react to validation errors


### PR DESCRIPTION
This PR:
* adds a logic that makes sure that the same DID that initially submitted a response to the exchange is the same DID that is obtaining the credentials
* adds custom exceptions: `TransactionEntityException`, `TransactionDidForbiddenException`
* adds global exception filter: `TransactionEntityExceptionFilter`