### PR TITLE
fix(input-desc-to-cred): fixing ESLint errors 

### DIFF
--- a/apps/credential-from-input-descriptor/tsconfig.json
+++ b/apps/credential-from-input-descriptor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src"],
+  "include": ["src", "test"],
   "compilerOptions": {
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
This PR fixes ESLint errors thrown for the files in the tests folder