### PR TITLE
feat: displaying a license on start

### DIFF
--- a/apps/credential-from-input-descriptor/Dockerfile
+++ b/apps/credential-from-input-descriptor/Dockerfile
@@ -28,6 +28,7 @@ ENV NODE_ENV=production
 
 EXPOSE 3000
 
+COPY license-header.txt /app
 COPY --from=builder /app/common/deploy /app
 
 CMD ["node", "apps/credential-from-input-descriptor/dist/main.js"]

--- a/apps/credential-from-input-descriptor/src/main.ts
+++ b/apps/credential-from-input-descriptor/src/main.ts
@@ -20,6 +20,8 @@ import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
 import { setupApp, setupSwaggerDocument } from './setup';
 import { SwaggerModule } from '@nestjs/swagger';
+import { readFile } from 'fs/promises';
+import { resolve as resolvePath } from 'path';
 
 async function bootstrap() {
   const logger = new Logger('bootstrap', { timestamp: true });
@@ -31,6 +33,9 @@ async function bootstrap() {
 
   const port = parseInt(process.env.PORT) || 3000;
   await app.listen(port);
+  console.log(
+    '\n' + (await readFile(resolvePath(__dirname, '..', '..', '..', 'license-header.txt'))).toString() + '\n'
+  );
   logger.log(`listening on http://127.0.0.1:${port}`);
   logger.log(`Swagger available on http://127.0.0.1:${port}/api`);
 }

--- a/apps/vc-api/src/main.ts
+++ b/apps/vc-api/src/main.ts
@@ -16,11 +16,18 @@
  */
 
 import { setupApp, setupSwaggerDocument } from './setup';
+import { readFile } from 'fs/promises';
+import { resolve as resolvePath } from 'path';
 
 async function bootstrap() {
   const app = await setupApp();
   setupSwaggerDocument(app);
   await app.listen(3000);
+  console.log(
+    '\n' +
+      (await readFile(resolvePath(__dirname, '..', '..', '..', '..', 'license-header.txt'))).toString() +
+      '\n'
+  );
 }
 
 bootstrap();


### PR DESCRIPTION
This PR displays a license on the applications start. The message content is taken from the `license-header.txt` file from the repository root