### PR TITLE
chore: renaming master branch to development

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ['master']
+    branches: ['development']
     paths-ignore: ['devops/**']
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
         id: env_vars
         run: |
           echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/development" ]; then
             echo "::set-output name=aws_region::${{ secrets.AWS_REGION }}"
             echo "::set-output name=aws_access_key_id_ssi::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
             echo "::set-output name=aws_secret_key_ssi::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
@@ -56,7 +56,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: master
+          release_branches: development
           custom_release_rules: major:major:Major Changes,minor:minor:Minor Changes,chore:patch:Chores
 
       - name: Create a GitHub release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and deploy
 
 on:
   push:
-    branches: ['development']
+    branches: ['develop']
     paths-ignore: ['devops/**']
   workflow_dispatch:
 
@@ -31,7 +31,7 @@ jobs:
         id: env_vars
         run: |
           echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/development" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
             echo "::set-output name=aws_region::${{ secrets.AWS_REGION }}"
             echo "::set-output name=aws_access_key_id_ssi::${{ secrets.DEV_AWS_ACCESS_KEY_ID }}"
             echo "::set-output name=aws_secret_key_ssi::${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}"
@@ -56,7 +56,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: development
+          release_branches: develop
           custom_release_rules: major:major:Major Changes,minor:minor:Minor Changes,chore:patch:Chores
 
       - name: Create a GitHub release

--- a/contributing.md
+++ b/contributing.md
@@ -37,7 +37,7 @@ If a maintainer asks you to "rebase" your PR, they're saying that a lot of code 
 
 ## Pull request process
 
- 1. Fork the repo, clone it to your own machine and create your branch from `master`
+ 1. Fork the repo, clone it to your own machine and create your branch from `development`
  2. Commit changes to your branch
  3. If you've added code that should be tested, add tests
  4. If you've changed APIs, or if needed, update the documentation, README, etc.
@@ -55,7 +55,7 @@ Don't forget to review your own code first. Does it make sense? Did you include 
 
 Our code review process is based on the following guidelines:
 * [Gitlab's Code Review Guidelines](https://gitlab.com/help/development/code_review.md)
-* [thoughtbot's Code Review Guidelines](https://github.com/thoughtbot/guides/tree/master/code-review)
+* [thoughtbot's Code Review Guidelines](https://github.com/thoughtbot/guides/tree/development/code-review)
 
 Especially pay attention to the ["Having your code reviewed"](https://gitlab.com/help/development/code_review.md#having-your-code-reviewed) section.
 

--- a/contributing.md
+++ b/contributing.md
@@ -55,7 +55,7 @@ Don't forget to review your own code first. Does it make sense? Did you include 
 
 Our code review process is based on the following guidelines:
 * [Gitlab's Code Review Guidelines](https://gitlab.com/help/development/code_review.md)
-* [thoughtbot's Code Review Guidelines](https://github.com/thoughtbot/guides/tree/development/code-review)
+* [thoughtbot's Code Review Guidelines](https://github.com/thoughtbot/guides/tree/master/code-review)
 
 Especially pay attention to the ["Having your code reviewed"](https://gitlab.com/help/development/code_review.md#having-your-code-reviewed) section.
 

--- a/contributing.md
+++ b/contributing.md
@@ -37,7 +37,7 @@ If a maintainer asks you to "rebase" your PR, they're saying that a lot of code 
 
 ## Pull request process
 
- 1. Fork the repo, clone it to your own machine and create your branch from `development`
+ 1. Fork the repo, clone it to your own machine and create your branch from `develop`
  2. Commit changes to your branch
  3. If you've added code that should be tested, add tests
  4. If you've changed APIs, or if needed, update the documentation, README, etc.

--- a/rush.json
+++ b/rush.json
@@ -281,7 +281,7 @@
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "master"
      */
-    "defaultBranch": "development"
+    "defaultBranch": "develop"
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is
      * not set or if a remote matching the provided remote URL is not found.

--- a/rush.json
+++ b/rush.json
@@ -281,7 +281,7 @@
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "master"
      */
-    // "defaultBranch": "master",
+    "defaultBranch": "development"
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is
      * not set or if a remote matching the provided remote URL is not found.


### PR DESCRIPTION
This PR implements changes needed to rename the `master` branch to the `development` branch.