### PR TITLE
fix: callback body validation errors

### DIFF
--- a/apps/vc-api/src/vc-api/credentials/dtos/authenticate.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/authenticate.dto.ts
@@ -17,6 +17,7 @@
 
 import { IsString, ValidateNested } from 'class-validator';
 import { ProvePresentationOptionsDto } from './prove-presentation-options.dto';
+import { Type } from 'class-transformer';
 
 /**
  * DTO which contains DID holder to authenticate and options
@@ -26,5 +27,6 @@ export class AuthenticateDto {
   did: string;
 
   @ValidateNested()
+  @Type(() => ProvePresentationOptionsDto)
   options: ProvePresentationOptionsDto;
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsString, IsDate, IsArray, IsObject, IsOptional, IsJSON } from 'class-validator';
+import { IsArray, IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
 
 /**
  * A JSON-LD Verifiable Credential without a proof.
@@ -52,7 +52,7 @@ export class CredentialDto {
   /**
    * The issuanceDate
    */
-  @IsDate()
+  @IsDateString()
   issuanceDate: string;
 
   /**

--- a/apps/vc-api/src/vc-api/credentials/dtos/issue-credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issue-credential.dto.ts
@@ -18,14 +18,17 @@
 import { ValidateNested } from 'class-validator';
 import { CredentialDto } from './credential.dto';
 import { IssueOptionsDto } from './issue-options.dto';
+import { Type } from 'class-transformer';
 
 /**
  * DTO which contains credential and options
  */
 export class IssueCredentialDto {
   @ValidateNested()
+  @Type(() => CredentialDto)
   credential: CredentialDto;
 
+  @Type(() => IssueOptionsDto)
   @ValidateNested()
   options: IssueOptionsDto;
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
@@ -19,6 +19,7 @@ import { IsString, IsArray, IsOptional, ValidateNested, IsJSON } from 'class-val
 import { VerifiableCredentialDto } from './verifiable-credential.dto';
 import { IsStringOrStringArray } from './custom-class-validator/is-string-or-string-array';
 import { Presentation } from '../../exchanges/types/presentation';
+import { Type } from 'class-transformer';
 
 /**
  * A JSON-LD Verifiable Presentation without a proof.
@@ -57,5 +58,6 @@ export class PresentationDto implements Presentation {
    * The Verifiable Credentials
    */
   @ValidateNested()
+  @Type(() => VerifiableCredentialDto)
   verifiableCredential: VerifiableCredentialDto[];
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
@@ -60,5 +60,6 @@ export class PresentationDto implements Presentation {
   @ValidateNested({ each: true })
   @Type(() => VerifiableCredentialDto)
   @IsArray()
-  verifiableCredential: VerifiableCredentialDto[];
+  @IsOptional()
+  verifiableCredential?: VerifiableCredentialDto[];
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/presentation.dto.ts
@@ -57,7 +57,8 @@ export class PresentationDto implements Presentation {
   /**
    * The Verifiable Credentials
    */
-  @ValidateNested()
+  @ValidateNested({ each: true })
   @Type(() => VerifiableCredentialDto)
+  @IsArray()
   verifiableCredential: VerifiableCredentialDto[];
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/prove-presentation.dto.ts
@@ -18,14 +18,17 @@
 import { ValidateNested } from 'class-validator';
 import { PresentationDto } from './presentation.dto';
 import { ProvePresentationOptionsDto } from './prove-presentation-options.dto';
+import { Type } from 'class-transformer';
 
 /**
  * DTO which contains presentation and options
  */
 export class ProvePresentationDto {
   @ValidateNested()
+  @Type(() => PresentationDto)
   presentation: PresentationDto;
 
   @ValidateNested()
+  @Type(() => ProvePresentationOptionsDto)
   options: ProvePresentationOptionsDto;
 }

--- a/apps/vc-api/src/vc-api/exchanges/dtos/exchange-response.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/exchange-response.dto.ts
@@ -18,6 +18,7 @@
 import { IsArray, IsBoolean, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { VerifiablePresentationDto } from 'src/vc-api/credentials/dtos/verifiable-presentation.dto';
 import { VpRequestDto } from './vp-request.dto';
+import { Type } from 'class-transformer';
 
 /**
  * Describes the possible contents of response to a start/continue exchange request
@@ -37,6 +38,7 @@ export class ExchangeResponseDto {
    * May not be returned if no further information is required (for example, at the end of the workflow)
    */
   @ValidateNested()
+  @Type(() => VpRequestDto)
   @IsOptional()
   vpRequest?: VpRequestDto;
 
@@ -44,6 +46,7 @@ export class ExchangeResponseDto {
    * If it is an issuance response, then a vp may be provided
    */
   @ValidateNested()
+  @Type(() => VerifiablePresentationDto)
   @IsOptional()
   vp?: VerifiablePresentationDto;
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -137,8 +137,8 @@ export class ExchangeService {
 
     callback?.forEach((callback) => {
       this.httpService.post(callback.url, body).subscribe({
-        next: (v) => Logger.log(inspect(v)), // inspect used to replace circular references https://stackoverflow.com/a/18354289
-        error: (e) => Logger.error(inspect(e))
+        next: (v) => this.logger.log(inspect(v)), // inspect used to replace circular references https://stackoverflow.com/a/18354289
+        error: (e) => this.logger.error(inspect(e))
       });
     });
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -124,7 +124,11 @@ export class ExchangeService {
       } as PresentationSubmissionEntity
     } as TransactionEntity);
 
-    const validationErrors = await validate(body, { whitelist: true, forbidUnknownValues: true });
+    const validationErrors = await validate(body, {
+      whitelist: true,
+      forbidUnknownValues: true,
+      forbidNonWhitelisted: false // here we want properties not defined in the CallbackDto to be just stripped out and not sent to a callback endpoint
+    });
 
     if (validationErrors.length > 0) {
       this.logger.error('\n' + validationErrors.map((e) => e.toString()).join('\n\n'));

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -36,6 +36,8 @@ import { PresentationSubmissionEntity } from './entities/presentation-submission
 
 @Injectable()
 export class ExchangeService {
+  private readonly logger = new Logger(ExchangeService.name, { timestamp: true });
+
   constructor(
     private vpSubmissionVerifierService: VpSubmissionVerifierService,
     @InjectRepository(TransactionEntity)
@@ -125,6 +127,7 @@ export class ExchangeService {
     const validationErrors = await validate(body, { whitelist: true, forbidUnknownValues: true });
 
     if (validationErrors.length > 0) {
+      this.logger.error('\n' + validationErrors.map((e) => e.toString()).join('\n\n'));
       throw new Error(validationErrors.toString());
     }
 

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -122,7 +122,6 @@ export class ExchangeService {
       } as PresentationSubmissionEntity
     } as TransactionEntity);
 
-    // TODO: react to validation errors
     const validationErrors = await validate(body, { whitelist: true, forbidUnknownValues: true });
 
     if (validationErrors.length > 0) {

--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -124,6 +124,11 @@ export class ExchangeService {
 
     // TODO: react to validation errors
     const validationErrors = await validate(body, { whitelist: true, forbidUnknownValues: true });
+
+    if (validationErrors.length > 0) {
+      throw new Error(validationErrors.toString());
+    }
+
     callback?.forEach((callback) => {
       this.httpService.post(callback.url, body).subscribe({
         next: (v) => Logger.log(inspect(v)), // inspect used to replace circular references https://stackoverflow.com/a/18354289

--- a/apps/vc-api/src/vc-api/exchanges/types/presentation.ts
+++ b/apps/vc-api/src/vc-api/exchanges/types/presentation.ts
@@ -47,5 +47,5 @@ export interface Presentation {
   /**
    * The Verifiable Credentials
    */
-  verifiableCredential: VerifiableCredential[];
+  verifiableCredential?: VerifiableCredential[];
 }

--- a/tests/e2e/src/main-suite.e2e-spec.ts
+++ b/tests/e2e/src/main-suite.e2e-spec.ts
@@ -132,7 +132,7 @@ describe('E2E Suite', function () {
           {
             path: ['$.id'],
             filter: {
-              const: 'https://issuer.oidp.uscis.gov/credentials/83627465'
+              const: 'urn:uuid:49f69fb8-f256-4b2e-b15d-c7ebec3a507e'
             }
           },
           {

--- a/tests/e2e/src/main-suite.e2e-spec.ts
+++ b/tests/e2e/src/main-suite.e2e-spec.ts
@@ -130,6 +130,12 @@ describe('E2E Suite', function () {
       constraints: {
         fields: [
           {
+            path: ['$.id'],
+            filter: {
+              const: 'https://issuer.oidp.uscis.gov/credentials/83627465'
+            }
+          },
+          {
             path: ['$.@context'],
             filter: {
               $schema: 'http://json-schema.org/draft-07/schema#',
@@ -227,6 +233,7 @@ describe('E2E Suite', function () {
           it('should contain expected properties', async function () {
             expect(Object.keys(body)).toEqual([
               '@context',
+              'id',
               'type',
               'credentialSubject',
               'issuer',


### PR DESCRIPTION
This PR:

- adds logic that throws an exception after callback body validation returns errors
- fixes bugs causing validation errors for a valid callback body
- fixes nested objects not validated in DTOs
- fixes tests failing after fixing DTOs validations
- fixes Presentation.verifiableCredential defined as mandatory, but it is actually optional according to the [vc-data-model](https://www.w3.org/TR/vc-data-model/#presentations-0)