### PR TITLE
fix: fixing presentation errors not handled

### DIFF
--- a/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/exchange.service.ts
@@ -114,6 +114,11 @@ export class ExchangeService {
       verifiablePresentation,
       this.vpSubmissionVerifierService
     );
+
+    if (response.errors.length > 0) {
+      throw new Error(`processing the presentation failed:\n\t${response.errors.join('\n\t')}`);
+    }
+
     await this.transactionRepository.save(transaction);
 
     const body = CallbackDto.toDto({


### PR DESCRIPTION
This PR fixes errors not handled after presentation processing fails. This results in some conditions in data processing continuing and the callback body not passing validations.