### PR TITLE
docs(vc-api): improve presentation-definition docs

### DIFF
--- a/apps/vc-api/docs/exchanges.md
+++ b/apps/vc-api/docs/exchanges.md
@@ -113,22 +113,6 @@ sequenceDiagram
   end
 ```
 
-## Exchange Interaction Types
-
-The exchange interaction types used by this VC-API implementation are directly related to Verifiable Presentation Request [Interaction Types](https://w3c-ccg.github.io/vp-request-spec/#mediated-presentation).
-The interaction types indicate to the receiver of the presentation request how they can expect to interact further with the issuer/verifier.
-
-### Mediated Exchange Interactions
-
-Mediated exchange interactions signal to the receiver of the presentation request that the exchange is mediated by an additional component and may not be automatically processed.
-Mediated exchanges therefore allow for a review of presention submission by a human or automated process as well as the issuance of credentials based on this review.
-
-Due to the duration of the mediation process being unknown, the submitter of the verifiable presentation may have to query repeateadly in order to check if the result of the mediation is available.
-
-### Unmediated Exchange Interactions
-
-Mediated exchange interactions signal to the receiver of the presentation request that the exchange is not mediated by an additional component and can be automatically processed.
-
 ## Exchange Definitions
 
 In order to keep the VC-API implementation generic (not specific to any use-cases), exchanges are configured rather than coded into the application.
@@ -139,7 +123,24 @@ For details on the structure and properties of an exchange definition, see the [
 
 Exhange Definitions are currently non-standard and custom to this VC-API implementation.
 
-### Presentation Notifications
+### Exchange Definition Structure and Properties
+
+#### Exchange Queries
+
+The `query` property of the Exchange Definition defines which data is to be requested by the exchange.
+
+The types of queries supports are defined by [VpRequestQueryType](../src/vc-api/exchanges/types/vp-request-query-type.ts).
+
+##### Presentation Definition Queries
+
+A Presentation Definition is a [DIF specification](https://identity.foundation/presentation-exchange/#presentation-definition).
+It is used to "articulate what proofs a Verifier requires".
+
+Presentation Definitions must contain an `id` property and this property should be unique within the context that the definition will be used.
+Currently, the Presentation Definition `id` is **not** used by the VC-API implementation.
+For simplicity, it may be set to the same value as the [exchange id](../src/vc-api/exchanges/dtos/exchange-definition.dto.ts) or to an arbitrary UUID.
+
+#### Exchange Callbacks
 
 When defining an exchange, callbacks can be configured to allow parties to receive notice of a VP submitted in response to an exchange.
 Notifications consist of POST requests to the configured URLs.
@@ -147,7 +148,25 @@ A callback is configured by adding an entry to the callback array in the [Exchan
 
 For an example of the result of a callback notification, see the [Resident Card Tutorial](../docs/tutorials/resident-card-tutorial.md#17-authority-portal-check-for-notification-of-submitted-presentation).
 
-### Exchange Definition for Issuance
+#### Exchange Interact Services
+
+The exchange interaction types used by this VC-API implementation are directly related to Verifiable Presentation Request [Interaction Types](https://w3c-ccg.github.io/vp-request-spec/#mediated-presentation).
+The interaction types indicate to the receiver of the presentation request how they can expect to interact further with the issuer/verifier.
+
+##### Mediated Exchange Interactions
+
+Mediated exchange interactions signal to the receiver of the presentation request that the exchange is mediated by an additional component and may not be automatically processed.
+Mediated exchanges therefore allow for a review of presention submission by a human or automated process as well as the issuance of credentials based on this review.
+
+Due to the duration of the mediation process being unknown, the submitter of the verifiable presentation may have to query repeateadly in order to check if the result of the mediation is available.
+
+##### Unmediated Exchange Interactions
+
+Mediated exchange interactions signal to the receiver of the presentation request that the exchange is not mediated by an additional component and can be automatically processed.
+
+### Exchange Definition Examples
+
+#### Exchange Definition for Issuance
 
 For issuance, a [Mediated Exchange](./exchanges.md#mediated-exchange-interactions) is required.
 This is because the issued VC will often depend data supplied by the credential requester (the eventual "holder").
@@ -156,7 +175,7 @@ or the VC may contain a "trust level" attribute based on the data provided in a 
 
 An example exchange definition for issuance can be seen in the [Resident Card tutorial](./tutorials/resident-card-tutorial.md#authority-portal-configure-the-credential-issuance-exchange).
 
-### Exchange Definition For Presentation
+#### Exchange Definition For Presentation
 
 For credential presentations, either a [Mediated Exchange](./exchanges.md#mediated-exchange-interactions)
 or an [Unmediated Exchange](./exchanges.md#unmediated-exchange-interactions) can be used.

--- a/apps/vc-api/docs/tutorials/consent-tutorial.md
+++ b/apps/vc-api/docs/tutorials/consent-tutorial.md
@@ -29,7 +29,6 @@ From a technical point of view, in this tutorial, we have access to the server A
 ### Technical workflows
 
 The technical workflow is as follows:
-*TODO* fill in steps once written
 - [1 [Consent-Requesting portal] Configure the consent request exchange](#1-consent-requesting-portal-configure-the-consent-request-exchange)
 - [2 [Consent-Requesting portal] Provide an exchange invitation to the consenter](#2-consent-requesting-portal-provide-an-exchange-invitation-to-the-consenter)
 - [3 [Consenter] Initiate issuance exchange using the request URL](#3-consenter-initiate-issuance-exchange-using-the-request-url)
@@ -80,6 +79,8 @@ Please only use this service for this tutorial (or other non-production applicat
 To use the "Post Test Server" service with this tutorial, create a new request bucket from the website home page.
 Then, in the resulting page, copy the POST URL, including the domain, into the exchange definition below.
 Creating a new request bucket is to help you be sure that you are looking at the requests you (and not others) have created.
+
+For further documentation regarding the `presentationDefinition`, can be seen [here](../exchanges.md#presentation-definition-queries)
 
 ```json
 {

--- a/apps/vc-api/docs/tutorials/resident-card-tutorial.md
+++ b/apps/vc-api/docs/tutorials/resident-card-tutorial.md
@@ -967,7 +967,8 @@ Fill `exchangeId` in the json below.
 
 Note the constraint on the `$.type` path of the credential.
 This is used to require that the presented credential be of type "PermanentResidentCard".
-For more information on credential constraints, see the [Presentation Exchange specification](https://identity.foundation/presentation-exchange).
+For further documentation regarding the `presentationDefinition`, can be seen [here](../exchanges.md#presentation-definition-queries)
+
 
 ```json
 {

--- a/apps/vc-api/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/exchange-definition.dto.ts
@@ -42,6 +42,9 @@ export class ExchangeDefinitionDto {
   @Type(() => ExchangeInteractServiceDefinitionDto)
   interactServices: ExchangeInteractServiceDefinitionDto[];
 
+  /**
+   * Defines requests for data in the Verifiable Presentation
+   */
   @ValidateNested({ each: true })
   @IsArray()
   @Type(() => VpRequestQueryDto)

--- a/apps/vc-api/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/vp-request-query.dto.ts
@@ -22,12 +22,12 @@ import { VpRequestDidAuthQueryDto } from './vp-request-did-auth-query.dto';
 import { VpRequestPresentationDefinitionQueryDto } from './vp-request-presentation-defintion-query.dto';
 
 /**
- * https://w3c-ccg.github.io/vp-request-spec/#query-types
+ * https://w3c-ccg.github.io/vp-request-spec/#query-and-response-types
  */
 export class VpRequestQueryDto {
   /**
    * Query types as listed in the VP Request spec.
-   * https://w3c-ccg.github.io/vp-request-spec/#query-types
+   * https://w3c-ccg.github.io/vp-request-spec/#query-and-response-types
    *
    * The "PresentationDefinition" type is proposed here: https://github.com/w3c-ccg/vp-request-spec/issues/7
    */


### PR DESCRIPTION
Consolidating the "Exchange Definition Structure and Properties" information in documentation.
A main purpose of this documentation change is to provide further details about the Presentation Definition Id:
> Presentation Definitions must contain an `id` property and this property should be unique within the context that the definition will be used.
Currently, the Presentation Definition `id` is **not** used by the VC-API implementation.
For simplicity, it may be set to the same value as the [exchange id](../src/vc-api/exchanges/dtos/exchange-definition.dto.ts) or to an arbitrary UUID.