### PR TITLE
fix: fixing "500 internal server error" response

### DIFF
--- a/apps/vc-api/src/vc-api/exchanges/vp-submission-verifier.service.ts
+++ b/apps/vc-api/src/vc-api/exchanges/vp-submission-verifier.service.ts
@@ -113,10 +113,20 @@ export class VpSubmissionVerifierService implements SubmissionVerifier {
     const pex: PEX = new PEX();
 
     credentialQuery.forEach(({ presentationDefinition }, index) => {
-      const { errors: partialErrors } = pex.evaluatePresentation(
-        presentationDefinition,
-        presentation as IPresentation
-      );
+      let partialErrors;
+
+      try {
+        ({ errors: partialErrors } = pex.evaluatePresentation(
+          presentationDefinition,
+          presentation as IPresentation
+        ));
+      } catch (err) {
+        if (typeof err === 'string') {
+          partialErrors = [{ message: err }];
+        } else {
+          throw err;
+        }
+      }
 
       errors.push(
         ...partialErrors.map(


### PR DESCRIPTION
This PR implements a logic that makes `VpSubmissionVerifierService.verifyVpRequestSubmission` return an error item instead of throwing an exception resulting in a "500 internal server error" HTTP response.