### PR TITLE
feat: format openapi.json files after generating them

### DIFF
--- a/apps/input-descriptor-to-credential/package.json
+++ b/apps/input-descriptor-to-credential/package.json
@@ -20,7 +20,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "write-openapi": "ts-node ./scripts/write-open-api-json.ts",
+    "write-openapi": "ts-node ./scripts/write-open-api-json.ts && prettier -w docs/openapi.json",
     "update-openapi": "npm run write-openapi; git add docs/openapi.json"
   },
   "dependencies": {

--- a/apps/vc-api/package.json
+++ b/apps/vc-api/package.json
@@ -21,7 +21,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "write-openapi": "ts-node ./scripts/write-open-api-json.ts",
+    "write-openapi": "ts-node ./scripts/write-open-api-json.ts && prettier -w docs/openapi.json",
     "update-openapi": "npm run write-openapi; git add docs/openapi.json"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds `openapi.json` files formatting after generating them but before committing. This allows easier debugging in case of Swagger generation problems or inconsistencies after reordering commits.