### PR TITLE
Remove did label

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -51,14 +51,6 @@
         "tags": ["did"]
       }
     },
-    "/v1/did/label/{did}": {
-      "post": {
-        "operationId": "DIDController_label",
-        "parameters": [],
-        "responses": { "201": { "description": "" } },
-        "tags": ["did"]
-      }
-    },
     "/v1/vc-api/credentials/issue": {
       "post": {
         "operationId": "VcApiController_issueCredential",

--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -43,14 +43,6 @@
         "tags": ["did"]
       }
     },
-    "/v1/did/verification-method/{id}": {
-      "get": {
-        "operationId": "DIDController_getVerificationMethods",
-        "parameters": [{ "name": "id", "required": true, "in": "path", "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "" } },
-        "tags": ["did"]
-      }
-    },
     "/v1/vc-api/credentials/issue": {
       "post": {
         "operationId": "VcApiController_issueCredential",

--- a/apps/vc-api/src/did/did.controller.ts
+++ b/apps/vc-api/src/did/did.controller.ts
@@ -50,13 +50,4 @@ export class DIDController {
   async getByDID(@Param('did') did: string): Promise<DIDDocument> {
     return await this.didService.getDID(did);
   }
-
-  /**
-   * Retrieves a verification method
-   * @param id
-   */
-  @Get('/verification-method/:id')
-  async getVerificationMethods(@Param('id') id: string): Promise<VerificationMethod> {
-    throw new Error('Not implemented');
-  }
 }

--- a/apps/vc-api/src/did/did.controller.ts
+++ b/apps/vc-api/src/did/did.controller.ts
@@ -59,17 +59,4 @@ export class DIDController {
   async getVerificationMethods(@Param('id') id: string): Promise<VerificationMethod> {
     throw new Error('Not implemented');
   }
-
-  /**
-   * Update the descriptive information information related to a DID
-   * "label" is kept in DID module because there is a one to one mapping between a DID and its label
-   * @param did
-   * @param label
-   * @param description
-   * @returns A DIDLabel entity
-   */
-  @Post('/label/:did')
-  async label(did: string, label: string, description: string) {
-    throw new Error('Not implemented');
-  }
 }


### PR DESCRIPTION
Removing `GET did/label` and `GET verification/method`. For both of these methods, we have no plans to implement, so it is best not to clutter the API documentation.