### PR TITLE
feat: CredentialDto.issuer can be string or object

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -659,6 +659,7 @@
         },
         "required": ["id"]
       },
+      "IssuerDto": { "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] },
       "CredentialDto": {
         "type": "object",
         "properties": {
@@ -673,7 +674,10 @@
             "type": "array",
             "items": { "type": "string" }
           },
-          "issuer": { "type": "string", "description": "A JSON-LD Verifiable Credential Issuer." },
+          "issuer": {
+            "description": "A JSON-LD Verifiable Credential Issuer.",
+            "oneOf": [{ "$ref": "#/components/schemas/IssuerDto" }, { "type": "string" }]
+          },
           "issuanceDate": {
             "type": "string",
             "description": "The issuanceDate",
@@ -731,7 +735,10 @@
             "type": "array",
             "items": { "type": "string" }
           },
-          "issuer": { "type": "string", "description": "A JSON-LD Verifiable Credential Issuer." },
+          "issuer": {
+            "description": "A JSON-LD Verifiable Credential Issuer.",
+            "oneOf": [{ "$ref": "#/components/schemas/IssuerDto" }, { "type": "string" }]
+          },
           "issuanceDate": {
             "type": "string",
             "description": "The issuanceDate",

--- a/apps/vc-api/src/vc-api/credentials/credentials.service.ts
+++ b/apps/vc-api/src/vc-api/credentials/credentials.service.ts
@@ -69,7 +69,11 @@ export class CredentialsService implements CredentialVerifier {
   constructor(private didService: DIDService, private keyService: KeyService) {}
 
   async issueCredential(issueDto: IssueCredentialDto): Promise<VerifiableCredentialDto> {
-    const verificationMethod = await this.getVerificationMethodForDid(issueDto.credential.issuer);
+    const verificationMethod = await this.getVerificationMethodForDid(
+      typeof issueDto.credential.issuer === 'string'
+        ? issueDto.credential.issuer
+        : issueDto.credential.issuer.id
+    );
     const key = await this.getKeyForVerificationMethod(verificationMethod.id);
     const proofOptions = this.mapVcApiIssueOptionsToSpruceIssueOptions(
       issueDto.options || ({} as IssueOptionsDto),

--- a/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
@@ -16,13 +16,15 @@
  */
 
 import { IsArray, IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import { IsIssuer } from '../../exchanges/dtos/custom-validators';
+import { IssuerDto } from './issuer.dto';
 
 /**
  * A JSON-LD Verifiable Credential without a proof.
  * https://w3c-ccg.github.io/vc-api/issuer.html#operation/issueCredential
  */
+@ApiExtraModels(IssuerDto)
 export class CredentialDto {
   [key: string]: unknown;
 
@@ -45,8 +47,11 @@ export class CredentialDto {
   type: string[];
 
   @IsIssuer()
-  @ApiProperty({ description: 'A JSON-LD Verifiable Credential Issuer.' })
-  issuer: string;
+  @ApiProperty({
+    description: 'A JSON-LD Verifiable Credential Issuer.',
+    oneOf: [{ $ref: getSchemaPath(IssuerDto) }, { type: 'string' }]
+  })
+  issuer: string | IssuerDto;
 
   @IsDateString()
   @ApiProperty({ description: 'The issuanceDate', example: '2022-09-21T11:49:03.205Z' })

--- a/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/credential.dto.ts
@@ -17,6 +17,7 @@
 
 import { IsArray, IsDateString, IsObject, IsOptional, IsString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIssuer } from '../../exchanges/dtos/custom-validators';
 
 /**
  * A JSON-LD Verifiable Credential without a proof.
@@ -43,7 +44,7 @@ export class CredentialDto {
   @ApiProperty({ description: 'The JSON-LD type of the credential.' })
   type: string[];
 
-  @IsString()
+  @IsIssuer()
   @ApiProperty({ description: 'A JSON-LD Verifiable Credential Issuer.' })
   issuer: string;
 

--- a/apps/vc-api/src/vc-api/credentials/dtos/issuer.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issuer.dto.ts
@@ -22,4 +22,8 @@ export class IssuerDto {
   @IsString()
   @ApiProperty()
   id: string;
+
+  constructor(properties: Partial<IssuerDto>) {
+    Object.assign(this, properties);
+  }
 }

--- a/apps/vc-api/src/vc-api/credentials/dtos/issuer.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issuer.dto.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021, 2022 Energy Web Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class IssuerDto {
+  @IsString()
+  @ApiProperty()
+  id: string;
+}

--- a/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/index.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021, 2022 Energy Web Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export * from './issuer.validator';
+export * from './presentation-definition-credential-query.validator';

--- a/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
@@ -22,19 +22,25 @@ import {
   ValidationArguments,
   ValidationOptions,
   ValidatorConstraint,
-  ValidatorConstraintInterface
+  ValidatorConstraintInterface,
+  validate
 } from 'class-validator';
+import { IssuerDto } from '../../../credentials/dtos/issuer.dto';
 
-@ValidatorConstraint({ async: false })
+@ValidatorConstraint({ async: true })
 export class IsIssuerValidatorConstraint implements ValidatorConstraintInterface {
-  validate(value: unknown): Promise<boolean> | boolean {
+  async validate(value: unknown): Promise<boolean> {
     if (isString(value)) {
       return true;
     }
 
     if (isObject(value)) {
-      return true;
+      const instance = new IssuerDto(value);
+      const validationErrors = await validate(instance);
+      return validationErrors.length === 0;
     }
+
+    return false;
   }
 
   defaultMessage(validationArguments?: ValidationArguments): string {

--- a/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
@@ -37,6 +37,7 @@ export class IsIssuerValidatorConstraint implements ValidatorConstraintInterface
     if (isObject(value)) {
       const instance = new IssuerDto(value);
       const validationErrors = await validate(instance);
+      // TODO: check how to pass detailed message to the http response
       return validationErrors.length === 0;
     }
 

--- a/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/custom-validators/issuer.validator.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, 2022 Energy Web Foundation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  isObject,
+  isString,
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface
+} from 'class-validator';
+
+@ValidatorConstraint({ async: false })
+export class IsIssuerValidatorConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): Promise<boolean> | boolean {
+    if (isString(value)) {
+      return true;
+    }
+
+    if (isObject(value)) {
+      return true;
+    }
+  }
+
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return `${validationArguments.property} is not valid issuer`;
+  }
+}
+
+export function IsIssuer(options?: ValidationOptions) {
+  return function (object: unknown, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      validator: IsIssuerValidatorConstraint
+    });
+  };
+}

--- a/apps/vc-api/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.ts
+++ b/apps/vc-api/src/vc-api/exchanges/dtos/vp-request-presentation-defintion-query.dto.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsPresentationDefinitionCredentialQuery } from './custom-validators/presentation-definition-credential-query.validator';
+import { IsPresentationDefinitionCredentialQuery } from './custom-validators';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyObject, ValidateNested } from 'class-validator';
 import { PresentationDefinitionDto } from './presentation-definition.dto';

--- a/apps/vc-api/src/vc-api/exchanges/types/credential.ts
+++ b/apps/vc-api/src/vc-api/exchanges/types/credential.ts
@@ -39,7 +39,7 @@ export interface Credential {
   /**
    * A JSON-LD Verifiable Credential Issuer.
    */
-  issuer: string;
+  issuer: string | { id: string };
 
   /**
    * The issuanceDate


### PR DESCRIPTION
this PR:
- changes type of the `CredentialDto.issuer` property to accept it as a `string` or as an `{ id: string }` object
- implements custom @IsIssuer validator to handle both use cases 