### PR TITLE
fix: adding `IssueOptionsDto.proofPurpose` 

### DIFF
--- a/apps/vc-api/docs/openapi.json
+++ b/apps/vc-api/docs/openapi.json
@@ -692,9 +692,24 @@
         },
         "required": ["@context", "type", "issuer", "issuanceDate", "credentialSubject"]
       },
+      "ProofPurpose": {
+        "type": "string",
+        "enum": [
+          "assertionMethod",
+          "authentication",
+          "keyAgreement",
+          "contactAgreement",
+          "capabilityInvocation",
+          "capabilityDelegation"
+        ]
+      },
       "IssueOptionsDto": {
         "type": "object",
         "properties": {
+          "proofPurpose": {
+            "description": "The purpose of the proof. Default 'assertionMethod'.",
+            "$ref": "#/components/schemas/ProofPurpose"
+          },
           "created": {
             "type": "string",
             "description": "The date and time of the proof (with a maximum accuracy in seconds). Default current system time."
@@ -753,17 +768,6 @@
           "proof": { "type": "object", "description": "A JSON-LD Linked Data proof." }
         },
         "required": ["@context", "type", "issuer", "issuanceDate", "credentialSubject", "proof"]
-      },
-      "ProofPurpose": {
-        "type": "string",
-        "enum": [
-          "assertionMethod",
-          "authentication",
-          "keyAgreement",
-          "contactAgreement",
-          "capabilityInvocation",
-          "capabilityDelegation"
-        ]
       },
       "VerifyOptionsDto": {
         "type": "object",

--- a/apps/vc-api/src/vc-api/credentials/dtos/issue-options.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issue-options.dto.ts
@@ -15,14 +15,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsObject, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ProofPurpose } from '@sphereon/pex';
 
 /**
  * Options for specifying how the Data Integrity Proof is created for a credential issuance
  * https://w3c-ccg.github.io/vc-api/issuer.html#operation/issueCredential
  */
 export class IssueOptionsDto {
+  @IsString()
+  @IsEnum(ProofPurpose)
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: "The purpose of the proof. Default 'assertionMethod'.",
+    enum: ProofPurpose,
+    enumName: 'ProofPurpose'
+  })
+  /**
+   * TODO: this is out of spec (https://w3c-ccg.github.io/vc-api/#issue-credential),
+   * but required by https://github.com/w3c-ccg/vc-api-test-suite/blob/1280a75771ac933b7d0ebe4710eabed1fcd60eab/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js#L58-L58
+   */
+  proofPurpose?: ProofPurpose;
+
   @IsString()
   @IsOptional()
   @ApiPropertyOptional({

--- a/apps/vc-api/src/vc-api/credentials/dtos/verify-options.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/verify-options.dto.ts
@@ -16,7 +16,7 @@
  */
 
 import { ProofPurpose } from '@sphereon/pex';
-import { IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { VerifyOptions } from '../types/verify-options';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -34,6 +34,7 @@ export class VerifyOptionsDto implements VerifyOptions {
   verificationMethod?: string;
 
   @IsString()
+  @IsEnum(ProofPurpose)
   @IsOptional()
   @ApiPropertyOptional({
     description: "The purpose of the proof. Default 'assertionMethod'.",


### PR DESCRIPTION
This PR:
- adds `IssueOptionsDto.proofPurpose` field that is out of [specs](https://w3c-ccg.github.io/vc-api/#issue-credential), but required by the [W3CCG test suite](https://github.com/w3c-ccg/vc-api-test-suite/blob/1280a75771ac933b7d0ebe4710eabed1fcd60eab/packages/vc-http-api-test-server/__tests__/issueCredential.spec.js#L58-L58) 
- fixes a bug where `VerifyOptionsDto.proofPurpose` enum is not validated