### PR TITLE
chore: upgrading nodejs to v18.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18.12'
 
       - name: Cache Rush
         uses: actions/cache@v2

--- a/apps/input-descriptor-to-credential/Dockerfile
+++ b/apps/input-descriptor-to-credential/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10.0-alpine as base
+FROM node:18.12-alpine as base
 
 WORKDIR /app
 

--- a/apps/vc-api/Dockerfile
+++ b/apps/vc-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.10.0-alpine as base
+FROM node:18.12-alpine as base
 
 WORKDIR /app
 

--- a/rush.json
+++ b/rush.json
@@ -116,7 +116,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <=16.10.0",
+  "nodeSupportedVersionRange": ">=16",
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases
    * spend six months in a stabilization period before the first Long Term Support (LTS) version.


### PR DESCRIPTION
The application works well with the new version of the nodejs, so this PR:
- updates versions enforced in the `rush.json` and changes tests to be executed with nodejs@18.12
- updates base Docker image to the `node:18.12-alpine` for both `Dockerfile`s
- changes CI tests to be executed with `nodejs@18.12`