### PR TITLE
fix: fixing `credential` field is not required

### DIFF
--- a/apps/vc-api/src/vc-api/credentials/dtos/issue-credential.dto.ts
+++ b/apps/vc-api/src/vc-api/credentials/dtos/issue-credential.dto.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IsObject, IsOptional, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsNotEmptyObject, IsObject, IsOptional, ValidateNested } from 'class-validator';
 import { CredentialDto } from './credential.dto';
 import { IssueOptionsDto } from './issue-options.dto';
 import { Type } from 'class-transformer';
@@ -27,6 +27,8 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 export class IssueCredentialDto {
   @ValidateNested()
   @Type(() => CredentialDto)
+  @IsNotEmpty()
+  @IsNotEmptyObject()
   @ApiProperty({ type: CredentialDto })
   credential: CredentialDto;
 


### PR DESCRIPTION
This PR fixes `credential` field is not required by the `POST /v1/vc-api/credentials/issue` and as a result https://w3c-ccg.github.io/vc-api-issuer-test-suite/ failing.